### PR TITLE
Add title methods to CocinaRecord

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     uri (1.0.3)
+    webrick (1.9.1)
     yard (0.9.37)
 
 PLATFORMS
@@ -144,6 +145,7 @@ DEPENDENCIES
   simplecov (~> 0.22.0)
   simplecov-rspec (~> 0.4)
   standard (~> 1.3)
+  webrick (~> 1.9, >= 1.9.1)
   yard (~> 0.9.37)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Once you have the JSON, you can initialize a `CocinaRecord` object and start wor
 =>
 #<CocinaDisplay::CocinaRecord:0x000000012d11b600
 ...
-> record.titles
-=> ["Bugatti Type 51A. Road & Track Salon January 1957"]
+> record.title
+=> "Bugatti Type 51A. Road & Track Salon January 1957"
 > record.content_type
 => "image"
 > record.iiif_manifest_url 

--- a/cocina_display.gemspec
+++ b/cocina_display.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.22.0"
   spec.add_development_dependency "simplecov-rspec", "~> 0.4"
   spec.add_development_dependency "yard", "~> 0.9.37"
+  spec.add_development_dependency "webrick", "~> 1.9", ">= 1.9.1" # for yard server
 end

--- a/lib/cocina_display/cocina_record.rb
+++ b/lib/cocina_display/cocina_record.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require "janeway"
+require "json"
 require "uri"
 require "active_support"
 require "active_support/core_ext/object/blank"
 require "active_support/core_ext/hash/conversions"
+
+require_relative "title_builder"
 
 module CocinaDisplay
   # Public Cocina metadata for an SDR object, as fetched from PURL.
@@ -110,6 +113,28 @@ module CocinaDisplay
     # @return [Boolean]
     def collection?
       content_type == "collection"
+    end
+
+    # The main title for the object.
+    # @note If you need more formatting control, consider using {CocinaDisplay::TitleBuilder} directly.
+    # @return [String]
+    # @example
+    #   record.title #=> "Bugatti Type 51A. Road & Track Salon January 1957"
+    def title
+      CocinaDisplay::TitleBuilder.build(
+        cocina_doc.dig("description", "title"),
+        catalog_links: cocina_doc.dig("identification", "catalogLinks")
+      )
+    end
+
+    # Alternative or translated titles for the object. Does not include the main title.
+    # @return [Array<String>]
+    # @example
+    #  record.additional_titles #=> ["Alternate title 1", "Alternate title 2"]
+    def additional_titles
+      CocinaDisplay::TitleBuilder.additional_titles(
+        cocina_doc.dig("description", "title")
+      )
     end
 
     # Traverse nested FileSets and return an enumerator over their files.

--- a/spec/cocina_record_spec.rb
+++ b/spec/cocina_record_spec.rb
@@ -193,6 +193,42 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     end
   end
 
+  describe "#title" do
+    context "when there is a subtitle" do
+      let(:druid) { "bx658jh7339" }
+
+      it "returns the title formatted to include the subtitle" do
+        expect(subject.title).to eq "M. de Courville : [estampe]"
+      end
+    end
+
+    context "when there are escaped characters" do
+      let(:druid) { "bb112zx3193" }
+
+      it "renders the title correctly" do
+        expect(subject.title).to eq "Bugatti Type 51A. Road & Track Salon January 1957"
+      end
+    end
+  end
+
+  describe "#additional_titles" do
+    context "when there is an alternative title" do
+      let(:druid) { "nz187ct8959" }
+
+      it "returns the alternative title" do
+        expect(subject.additional_titles).to eq ["Two thousand and ten China province population census data with GIS maps"]
+      end
+    end
+
+    context "when there is a parallel translated title" do
+      let(:druid) { "bt553vr2845" }
+
+      it "returns the parallel title" do
+        expect(subject.additional_titles).to eq ["Master i Margarita. English"]
+      end
+    end
+  end
+
   describe "#created_time" do
     let(:druid) { "bx658jh7339" }
 


### PR DESCRIPTION
This adds some methods callable directly from CocinaRecord that
use TitleBuilder to output titles.

These are the most commonly used methods we have during indexing;
for more control you could use TitleBuilder directly.
