### PR TITLE
Port Date model from mods gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     cocina_display (0.2.0)
       activesupport (~> 8.0, >= 8.0.2)
+      edtf (~> 3.2)
       janeway-jsonpath (~> 0.6)
 
 GEM
@@ -34,6 +35,8 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
+    edtf (3.2.0)
+      activesupport (>= 3.0, < 9.0)
     erb (5.0.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)

--- a/cocina_display.gemspec
+++ b/cocina_display.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "janeway-jsonpath", "~> 0.6" # for nested JSON queries
   spec.add_dependency "activesupport", "~> 8.0", ">= 8.0.2" # for helpers like present?
+  spec.add_dependency "edtf", "~> 3.2" # for parsing dates
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/cocina_display/date.rb
+++ b/lib/cocina_display/date.rb
@@ -1,0 +1,670 @@
+require "edtf"
+
+require "active_support"
+require "active_support/core_ext/object/blank"
+require "active_support/core_ext/integer/inflections"
+
+module CocinaDisplay
+  module Dates
+    # A date to be converted to a Date object.
+    class Date
+      # Construct a Date from parsed Cocina data.
+      # @param cocina [Hash] Cocina date data
+      # @return [CocinaDisplay::Date]
+      def self.from_cocina(cocina)
+        # TODO: handle structuredValue arrays (date ranges)
+        return if cocina["structuredValue"].present?
+
+        # If an encoding was declared, use it. Cocina validates this
+        case cocina.dig("encoding", "code")
+        when "w3cdtf"
+          W3cdtfFormat.new(cocina)
+        when "iso8601"
+          Iso8601Format.new(cocina)
+        when "marc"
+          MarcFormat.new(cocina)
+        when "edtf"
+          EdtfFormat.new(cocina)
+        else  # No declared encoding, or unknown encoding
+          value = cocina["value"]
+
+          # Don't bother with weird unparseable values
+          date_class = UnparseableDate if value =~ /\p{Hebrew}/ || value =~ /^-/
+
+          # Try to match against known date formats using their regexes
+          # Order matters here; more specific formats should be checked first
+          date_class ||= [
+            MMDDYYYYFormat,
+            MMDDYYFormat,
+            YearRangeFormat,
+            DecadeAsYearDashFormat,
+            DecadeStringFormat,
+            EmbeddedBCYearFormat,
+            EmbeddedYearFormat,
+            EmbeddedThreeDigitYearFormat,
+            EmbeddedYearWithBracketsFormat,
+            MysteryCenturyFormat,
+            CenturyFormat,
+            RomanNumeralCenturyFormat,
+            RomanNumeralYearFormat,
+            OneOrTwoDigitYearFormat
+          ].find { |klass| klass.supports?(value) }
+
+          # If no specific format matched, use the base class
+          date_class ||= Date
+
+          date_class.new(cocina)
+        end
+      end
+
+      # Parse a string to a Date object according to the given encoding.
+      # Delegates to the parser subclass {normalize_to_edtf} method.
+      # @param value [String] the date value to parse
+      # @return [EDTF::Date]
+      # @return [nil] if the date is blank or invalid
+      def self.parse_date(value)
+        return if value.blank? || ["0000-00-00", "9999", "uuuu", "[uuuu]"].include?(value)
+
+        ::Date.edtf(normalize_to_edtf(value))
+      end
+
+      # Apply any encoding-specific munging or text extraction logic.
+      # @note This is the "fallback" version when no other parser matches.
+      # @param value [String] the date value to modify
+      # @return [String]
+      def self.normalize_to_edtf(value)
+        sanitized = value.gsub(/^[\[]+/, "").gsub(/[\.\]]+$/, "")
+        sanitized = value.rjust(4, "0") if /^\d{3}$/.match?(value)
+
+        sanitized
+      end
+
+      attr_reader :cocina, :date
+
+      def initialize(cocina)
+        @cocina = cocina
+        @date = self.class.parse_date(cocina["value"])
+      end
+
+      # Compare this date to another {Date} or {DateRange} using its {sort_key}.
+      def <=>(other)
+        sort_key <=> other.sort_key if other.is_a?(Date) || other.is_a?(DateRange)
+      end
+
+      # The text representation of the date, as stored in Cocina.
+      # @return [String]
+      def value
+        cocina["value"]
+      end
+
+      # The type of this date, if any, such as "creation", "publication", etc.
+      # @return [String, nil]
+      def type
+        cocina["type"]
+      end
+
+      # The qualifier for this date, if any, such as "approximate", "inferred", etc.
+      # @return [String, nil]
+      def qualifier
+        cocina["qualifier"]
+      end
+
+      # Does this date have a qualifier? E.g. "approximate", "inferred", etc.
+      # @return [Boolean]
+      def qualified?
+        qualifier.present?
+      end
+
+      # The encoding of this date, if specified.
+      # @example
+      #   date.encoding #=> "iso8601"
+      # @return [String, nil]
+      def encoding
+        cocina.dig("encoding", "code")
+      end
+
+      # Was an encoding declared for this date?
+      # @return [Boolean]
+      def encoding?
+        encoding.present?
+      end
+
+      # Is this the start date in a range?
+      # @return [Boolean]
+      def start?
+        type == "start"
+      end
+
+      # Is this the end date in a range?
+      # @return [Boolean]
+      def end?
+        type == "end"
+      end
+
+      # Was the date marked as approximate?
+      # @return [Boolean]
+      def approximate?
+        qualifier == "approximate"
+      end
+
+      # Was the date marked as inferred?
+      # @return [Boolean]
+      def inferred?
+        qualifier == "inferred"
+      end
+
+      # Was the date marked as approximate?
+      # @return [Boolean]
+      def questionable?
+        qualifier == "questionable"
+      end
+
+      # Was the date marked as primary?
+      # @note In MODS XML, this corresponds to the +keyDate+ attribute.
+      # @return [Boolean]
+      def primary?
+        cocina["status"] == "primary"
+      end
+
+      # Did we successfully parse a date from the Cocina data?
+      # @return [Boolean]
+      def parsed_date?
+        date.present?
+      end
+
+      # How precise is the parsed date information?
+      # @return [Symbol] :year, :month, :day, :decade, :century, or :unknown
+      def precision
+        return :unknown unless date_range || date
+
+        if date_range.is_a? EDTF::Century
+          :century
+        elsif date_range.is_a? EDTF::Decade
+          :decade
+        elsif date.is_a? EDTF::Season
+          :month
+        elsif date.is_a? EDTF::Interval
+          date.precision
+        else
+          case date.precision
+          when :month
+            date.unspecified.unspecified?(:month) ? :year : :month
+          when :day
+            d = date.unspecified.unspecified?(:day) ? :month : :day
+            date.unspecified.unspecified?(:month) ? :year : d
+          else
+            date.precision
+          end
+        end
+      end
+
+      # Used to sort BCE dates correctly in lexicographic order.
+      BCE_CHAR_SORT_MAP = {"0" => "9", "1" => "8", "2" => "7", "3" => "6", "4" => "5", "5" => "4", "6" => "3", "7" => "2", "8" => "1", "9" => "0"}.freeze
+
+      # Key used to sort this date. Respects BCE/CE ordering and precision.
+      # @return [String]
+      # @return [nil] if the date could not be parsed
+      def sort_key
+        return unless parsed_date?
+
+        # Use the start of an interval for sorting
+        sort_date = date.is_a?(EDTF::Interval) ? date.from : date
+
+        # Get the parsed year, month, and day values
+        year, month, day = if sort_date.respond_to?(:values)
+          sort_date.values
+        else
+          [sort_date.year, nil, nil]
+        end
+
+        # Format year into sortable string
+        year_str = if year > 0
+          # for CE dates, we can just pad them out to 4 digits and sort normally...
+          year.to_s.rjust(4, "0")
+        else
+          #  ... but for BCE, because we're sorting lexically, we need to invert the digits (replacing 0 with 9, 1 with 8, etc.),
+          #  we prefix it with a hyphen (which will sort before any digit) and the number of digits (also inverted) to get
+          # it to sort correctly.
+          inverted_year = year.abs.to_s.chars.map { |c| BCE_CHAR_SORT_MAP[c] }.join
+          length_prefix = BCE_CHAR_SORT_MAP[inverted_year.to_s.length.to_s]
+          "-#{length_prefix}#{inverted_year}"
+        end
+
+        # Format month and day into sortable strings, pad to 2 digits
+        month_str = month ? month.to_s.rjust(2, "0") : "00"
+        day_str = day ? day.to_s.rjust(2, "0") : "00"
+
+        # Join into a sortable string; add hyphens so decade/century sort first
+        case precision
+        when :decade
+          [year_str[0...-1], "-", month_str, day_str].join
+        when :century
+          [year_str[0...-2], "--", month_str, day_str].join
+        else
+          [year_str, month_str, day_str].join
+        end
+      end
+
+      # Decoded version of the date with "BCE" or "CE". Strips leading zeroes.
+      # @param allowed_precisions [Array<Symbol>] List of allowed precisions for the output.
+      #   Defaults to [:day, :month, :year, :decade, :century].
+      # @param ignore_unparseable [Boolean] Return nil instead of the original value if it couldn't be parsed
+      # @param display_original_value [Boolean] Return the original value if it was not encoded
+      # @return [String]
+      def decoded_value(allowed_precisions: [:day, :month, :year, :decade, :century], ignore_unparseable: false, display_original_value: true)
+        return if ignore_unparseable && !parsed_date?
+        return value.strip unless parsed_date?
+
+        if display_original_value
+          unless encoding?
+            return value.strip unless value =~ /^-?\d+$/ || value =~ /^[\dXxu?-]{4}$/
+          end
+        end
+
+        if date.is_a?(EDTF::Interval)
+          range = [
+            Date.format_date(date.min, date.min.precision, allowed_precisions),
+            Date.format_date(date.max, date.max.precision, allowed_precisions)
+          ].uniq.compact
+
+          return value.strip if range.empty?
+
+          range.join(" - ")
+        else
+          Date.format_date(date, precision, allowed_precisions) || value.strip
+        end
+      end
+
+      # Decoded date with "BCE" or "CE" and qualifier markers applied.
+      # @see decoded_value
+      # @see https://consul.stanford.edu/display/chimera/MODS+display+rules#MODSdisplayrules-3b.%3CoriginInfo%3E
+      def qualified_value
+        qualified_format = case qualifier
+        when "approximate"
+          "[ca. %s]"
+        when "questionable"
+          "[%s?]"
+        when "inferred"
+          "[%s]"
+        else
+          "%s"
+        end
+
+        format(qualified_format, decoded_value)
+      end
+
+      # Range between earliest possible date and latest possible date.
+      # @note Some encodings support disjoint sets of ranges, so this method could be less accurate than {#to_a}.
+      # @return [Range]
+      def as_range
+        return unless earliest_date && latest_date
+
+        earliest_date..latest_date
+      end
+
+      # Array of all years that fall into the range of possible dates in the data.
+      # @note Some encodings support disjoint sets of ranges, so this method could be more accurate than {#as_range}.
+      # @return [Array]
+      def to_a
+        case date
+        when EDTF::Set
+          date.to_a
+        else
+          as_range.to_a
+        end
+      end
+
+      private
+
+      class << self
+        # Returns the date in the format specified by the precision.
+        # Supports e.g. retrieving year precision when the actual date is more precise.
+        # @param date [EDTF::Date] The date to format.
+        # @param precision [Symbol] The precision to format the date at, e.g. :month
+        # @param allowed_precisions [Array<Symbol>] List of allowed precisions for the output.
+        #   Options are [:day, :month, :year, :decade, :century].
+        # @note allowed_precisions should be ordered by granularity, with most specific first.
+        def format_date(date, precision, allowed_precisions)
+          precision = allowed_precisions.first unless allowed_precisions.include?(precision)
+
+          case precision
+          when :day
+            date.strftime("%B %e, %Y")
+          when :month
+            date.strftime("%B %Y")
+          when :year
+            year = date.year
+            if year < 1
+              "#{year.abs + 1} BCE"
+            # Any dates before the year 1000 are explicitly marked CE
+            elsif year >= 1 && year < 1000
+              "#{year} CE"
+            else
+              year.to_s
+            end
+          when :decade
+            "#{EDTF::Decade.new(date.year).year}s"
+          when :century
+            if date.year.negative?
+              "#{((date.year / 100).abs + 1).ordinalize} century BCE"
+            else
+              "#{((date.year / 100) + 1).ordinalize} century"
+            end
+          end
+        end
+      end
+
+      # Earliest possible date encoded in data, respecting unspecified/imprecise info.
+      # @return [EDTF::Date]
+      def earliest_date
+        return nil if date.nil?
+
+        case date_range
+        when EDTF::Unknown
+          nil
+        when EDTF::Epoch, EDTF::Interval, EDTF::Season
+          date_range.min
+        when EDTF::Set
+          date_range.to_a.first
+        else
+          d = date.dup
+          d = d.change(month: 1, day: 1) if date.precision == :year
+          d = d.change(day: 1) if date.precision == :month
+          d = d.change(month: 1) if date.unspecified.unspecified? :month
+          d = d.change(day: 1) if date.unspecified.unspecified? :day
+          d
+        end
+      end
+
+      # Latest possible date encoded in data, respecting unspecified/imprecise info.
+      # @return [EDTF::Date]
+      def latest_date
+        return nil if date.nil?
+
+        case date_range
+        when EDTF::Unknown
+          nil
+        when EDTF::Epoch, EDTF::Interval, EDTF::Season
+          date_range.max
+        when EDTF::Set
+          date_range.to_a.last.change(month: 12, day: 31)
+        else
+          d = date.dup
+          d = d.change(month: 12, day: 31) if date.precision == :year
+          d = d.change(day: days_in_month(date.month, date.year)) if date.precision == :month
+          d = d.change(month: 12) if date.unspecified.unspecified? :month
+          d = d.change(day: days_in_month(date.month, date.year)) if date.unspecified.unspecified? :day
+          d
+        end
+      end
+
+      # Expand placeholders like "19XX" into an object representing the full range.
+      # @note This is different from dates with an explicit start/end in the Cocina.
+      # @see CocinaDisplay::Dates::DateRange
+      # @return [EDTF::Date]
+      def date_range
+        @date_range ||= if /u/.match?(value)
+          ::Date.edtf(value.tr("u", "x").tr("X", "x")) || date
+        else
+          date
+        end
+      end
+
+      # Helper for calculating days in a month, accounting for leap years.
+      # @param [Integer] month
+      # @param [Integer] year
+      # @return [Integer] Number of days in the month
+      def days_in_month(month, year)
+        if month == 2 && ::Date.gregorian_leap?(year)
+          29
+        else
+          [nil, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month]
+        end
+      end
+    end
+
+    # Strict ISO8601-encoded date parser.
+    class Iso8601Format < Date
+      def self.parse_date(value)
+        ::Date.parse(normalize_to_edtf(value))
+      end
+    end
+
+    # Less strict W3CDTF-encoded date parser.
+    class W3cdtfFormat < Date
+      def self.normalize_to_edtf(value)
+        super.gsub("-00", "")
+      end
+    end
+
+    # Strict EDTF parser.
+    class EdtfFormat < Date
+      attr_reader :date
+
+      def self.normalize_to_edtf(value)
+        return "0000" if value.strip == "0"
+
+        case value
+        when /^\d{1,3}$/
+          value.rjust(4, "0") if /^\d{1,3}$/.match?(value)
+        when /^-\d{1,3}$/
+          "-#{value.sub(/^-/, "").rjust(4, "0")}"
+        else
+          value
+        end
+      end
+    end
+
+    # MARC date parser; similar to EDTF but with some MARC-specific encodings.
+    class MarcFormat < Date
+      def self.normalize_to_edtf(value)
+        return nil if value == "9999" || value == "uuuu" || value == "||||"
+
+        super
+      end
+
+      private
+
+      def earliest_date
+        if value == "1uuu"
+          ::Date.parse("1000-01-01")
+        else
+          super
+        end
+      end
+
+      def latest_date
+        if value == "1uuu"
+          ::Date.parse("1999-12-31")
+        else
+          super
+        end
+      end
+    end
+
+    # Base class for date formats that match using a regex.
+    class ExtractorDateFormat < Date
+      def self.supports?(value)
+        value.match self::REGEX
+      end
+    end
+
+    # A date format that cannot be parsed or recognized.
+    class UnparseableDate < ExtractorDateFormat
+      def self.parse_date(value)
+        nil
+      end
+    end
+
+    # Extractor for MM/DD/YYYY and MM/DD/YYY-formatted dates
+    class MMDDYYYYFormat < ExtractorDateFormat
+      REGEX = /(?<month>\d{1,2})\/(?<day>\d{1,2})\/(?<year>\d{3,4})/
+
+      def self.normalize_to_edtf(value)
+        matches = value.match(self::REGEX)
+        "#{matches[:year].rjust(4, "0")}-#{matches[:month].rjust(2, "0")}-#{matches[:day].rjust(2, "0")}"
+      end
+    end
+
+    # Extractor for MM/DD/YY-formatted dates
+    class MMDDYYFormat < ExtractorDateFormat
+      REGEX = /(?<month>\d{1,2})\/(?<day>\d{1,2})\/(?<year>\d{2})/
+
+      def self.normalize_to_edtf(value)
+        matches = value.match(self::REGEX)
+        year = munge_to_yyyy(matches[:year])
+        "#{year}-#{matches[:month].rjust(2, "0")}-#{matches[:day].rjust(2, "0")}"
+      end
+
+      # For two-digit year, if it would be in the future, more likely to just
+      # be the previous century. 12/1/99 -> 1999
+      def self.munge_to_yyyy(year)
+        if year.to_i > (::Date.current.year - 2000)
+          "19#{year}"
+        else
+          "20#{year}"
+        end
+      end
+    end
+
+    # Extractor for dates encoded as Roman numerals.
+    class RomanNumeralYearFormat < ExtractorDateFormat
+      REGEX = /(?<![A-Za-z\.])(?<year>[MCDLXVI\.]+)(?![A-Za-z])/
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        roman_to_int(matches[:year].upcase).to_s
+      end
+
+      def self.roman_to_int(value)
+        value = value.tr(".", "")
+        map = {"M" => 1000, "CM" => 900, "D" => 500, "CD" => 400, "C" => 100, "XC" => 90, "L" => 50, "XL" => 40, "X" => 10, "IX" => 9, "V" => 5, "IV" => 4, "I" => 1}
+        result = 0
+        map.each do |k, v|
+          while value.index(k) == 0
+            result += v
+            value.slice! k
+          end
+        end
+        result
+      end
+    end
+
+    # Extractor for centuries encoded as Roman numerals; sometimes centuries
+    # are given as e.g. xvith, hence the funny negative look-ahead assertion
+    class RomanNumeralCenturyFormat < RomanNumeralYearFormat
+      REGEX = /(?<![a-z])(?<century>[xvi]+)(?![a-su-z])/
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        munge_to_yyyy(matches[:century])
+      end
+
+      def self.munge_to_yyyy(text)
+        value = roman_to_int(text.upcase)
+        (value - 1).to_s.rjust(2, "0") + "xx"
+      end
+    end
+
+    # Extractor for a flavor of century encoding present in Stanford data
+    # of unknown origin.
+    class MysteryCenturyFormat < ExtractorDateFormat
+      REGEX = /(?<century>\d{2})--/
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        "#{matches[:century]}xx"
+      end
+    end
+
+    # Extractor for dates given as centuries
+    class CenturyFormat < ExtractorDateFormat
+      REGEX = /(?<century>\d{2})th C(?:entury)?/i
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        "#{matches[:century].to_i - 1}xx"
+      end
+    end
+
+    # Extractor for data formatted as YYYY-YYYY or YYY-YYY
+    class YearRangeFormat < ExtractorDateFormat
+      REGEX = /(?<start>\d{3,4})-(?<end>\d{3,4})/
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        "#{matches[:start].rjust(4, "0")}/#{matches[:end].rjust(4, "0")}"
+      end
+    end
+
+    # Extractor for data formatted as YYY-
+    class DecadeAsYearDashFormat < ExtractorDateFormat
+      REGEX = /(?<!\d)(?<year>\d{3})[-_xu?](?!\d)/
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        "#{matches[:year]}x"
+      end
+    end
+
+    # Extractor for data formatted as YYY0s
+    class DecadeStringFormat < ExtractorDateFormat
+      REGEX = /(?<!\d)(?<year>\d{3})0s(?!\d)/
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        "#{matches[:year]}x"
+      end
+    end
+
+    # Extractor that tries hard to pick any BC year present in the data
+    class EmbeddedBCYearFormat < ExtractorDateFormat
+      REGEX = /(?<year>\d{3,4})\s?B\.?C\.?/i
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        "-#{(matches[:year].to_i - 1).to_s.rjust(4, "0")}"
+      end
+    end
+
+    # Extractor that tries hard to pick any year present in the data
+    class EmbeddedYearFormat < ExtractorDateFormat
+      REGEX = /(?<!\d)(?<year>\d{4})(?!\d)/
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        matches[:year].rjust(4, "0")
+      end
+    end
+
+    # Extractor that tries hard to pick any 3-digit year present in the data
+    class EmbeddedThreeDigitYearFormat < ExtractorDateFormat
+      REGEX = /(?<!\d)(?<year>\d{3})(?!\d)(?!\d)/
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        matches[:year].rjust(4, "0")
+      end
+    end
+
+    # Extractor that tries hard to pick any 1- or 2-digit year present in the data
+    class OneOrTwoDigitYearFormat < ExtractorDateFormat
+      REGEX = /^(?<year>\d{1,2})$/
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        matches[:year].rjust(4, "0")
+      end
+    end
+
+    # Full-text extractor that tries hard to pick any bracketed year present in the data
+    class EmbeddedYearWithBracketsFormat < ExtractorDateFormat
+      # [YYY]Y Y[YYY] [YY]YY Y[YY]Y YY[YY] YYY[Y] YY[Y]Y Y[Y]YY [Y]YYY
+      REGEX = /(?<year>[\d\[\]]{6})(?!\d)/
+
+      def self.normalize_to_edtf(text)
+        matches = text.match(REGEX)
+        matches[:year].delete("[").delete("]")
+      end
+    end
+  end
+end

--- a/spec/date_spec.rb
+++ b/spec/date_spec.rb
@@ -1,0 +1,548 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require_relative "../lib/cocina_display/date"
+
+RSpec.describe CocinaDisplay::Dates::Date do
+  subject(:date) { described_class.from_cocina(cocina) }
+
+  describe "#value" do
+    let(:cocina) { {"value" => "2023"} }
+
+    it "returns the cocina value" do
+      expect(date.value).to eq("2023")
+    end
+  end
+
+  describe "#type" do
+    let(:cocina) { {"value" => "2023", "type" => "creation"} }
+
+    it "returns the cocina type attribute" do
+      expect(date.type).to eq("creation")
+    end
+  end
+
+  describe "#qualifier" do
+    let(:cocina) { {"value" => "2023", "qualifier" => "approximate"} }
+
+    it "returns the cocina qualifier attribute" do
+      expect(date.qualifier).to eq("approximate")
+    end
+  end
+
+  describe "qualified?" do
+    context "when the date is qualified" do
+      let(:cocina) { {"value" => "2023", "qualifier" => "questionable"} }
+
+      it "returns true" do
+        expect(date.qualified?).to be true
+      end
+    end
+
+    context "when the date is not qualified" do
+      let(:cocina) { {"value" => "2023"} }
+
+      it "returns false" do
+        expect(date.qualified?).to be false
+      end
+    end
+  end
+
+  describe "#encoding" do
+    let(:cocina) { {"value" => "2023-01-01", "encoding" => {"code" => "iso8601"}} }
+
+    it "returns the cocina encoding attribute" do
+      expect(date.encoding).to eq("iso8601")
+    end
+  end
+
+  describe "#encoding?" do
+    context "when encoding is present" do
+      let(:cocina) { {"value" => "2023-01-01", "encoding" => {"code" => "iso8601"}} }
+
+      it "returns true" do
+        expect(date.encoding?).to be true
+      end
+    end
+
+    context "when encoding is not present" do
+      let(:cocina) { {"value" => "2023"} }
+
+      it "returns false" do
+        expect(date.encoding?).to be false
+      end
+    end
+  end
+
+  describe "#start?" do
+    context "when the date is a start date" do
+      let(:cocina) { {"value" => "2023-01-01", "type" => "start"} }
+      it "returns true" do
+        expect(date.start?).to be true
+      end
+    end
+  end
+
+  describe "#end?" do
+    context "when the date is an end date" do
+      let(:cocina) { {"value" => "2023-01-01", "type" => "end"} }
+      it "returns true" do
+        expect(date.end?).to be true
+      end
+    end
+  end
+
+  describe "#primary?" do
+    context "when status is primary" do
+      let(:cocina) { {"value" => "2023", "status" => "primary"} }
+
+      it "returns true" do
+        expect(date.primary?).to be true
+      end
+    end
+
+    context "when status is not primary" do
+      let(:cocina) { {"value" => "2023", "status" => "secondary"} }
+
+      it "returns false" do
+        expect(date.primary?).to be false
+      end
+    end
+  end
+
+  describe "#questionable?" do
+    context "when qualifier is questionable" do
+      let(:cocina) { {"value" => "2023", "qualifier" => "questionable"} }
+
+      it "returns true" do
+        expect(date.questionable?).to be true
+      end
+    end
+
+    context "when qualifier is not questionable" do
+      let(:cocina) { {"value" => "2023", "qualifier" => "approximate"} }
+
+      it "returns false" do
+        expect(date.questionable?).to be false
+      end
+    end
+  end
+
+  describe "#inferred?" do
+    context "when qualifier is inferred" do
+      let(:cocina) { {"value" => "2023", "qualifier" => "inferred"} }
+
+      it "returns true" do
+        expect(date.inferred?).to be true
+      end
+    end
+
+    context "when qualifier is not inferred" do
+      let(:cocina) { {"value" => "2023", "qualifier" => "approximate"} }
+
+      it "returns false" do
+        expect(date.inferred?).to be false
+      end
+    end
+  end
+
+  describe "#approximate?" do
+    context "when qualifier is approximate" do
+      let(:cocina) { {"value" => "2023", "qualifier" => "approximate"} }
+
+      it "returns true" do
+        expect(date.approximate?).to be true
+      end
+    end
+
+    context "when qualifier is not approximate" do
+      let(:cocina) { {"value" => "2023", "qualifier" => "inferred"} }
+
+      it "returns false" do
+        expect(date.approximate?).to be false
+      end
+    end
+  end
+
+  describe "#parsed_date?" do
+    context "when the date is parsable" do
+      let(:cocina) { {"value" => "2023"} }
+
+      it "returns true" do
+        expect(date.parsed_date?).to be true
+      end
+    end
+
+    context "when the date is not parsable" do
+      let(:cocina) { {"value" => "invalid-date"} }
+
+      it "returns false" do
+        expect(date.parsed_date?).to be false
+      end
+    end
+  end
+
+  describe "#precision" do
+    context "with a century date" do
+      let(:cocina) { {"value" => "19xx", "encoding" => {"code" => "edtf"}} }
+
+      it "returns :century" do
+        expect(date.precision).to eq(:century)
+      end
+    end
+
+    context "with a decade" do
+      let(:cocina) { {"value" => "196x", "encoding" => {"code" => "edtf"}} }
+
+      it "returns :decade" do
+        expect(date.precision).to eq(:decade)
+      end
+    end
+
+    context "with a season" do
+      # Spring 1960 in EDTF
+      let(:cocina) { {"value" => "1960-21", "encoding" => {"code" => "edtf"}} }
+
+      it "returns :month" do
+        expect(date.precision).to eq(:month)
+      end
+    end
+
+    context "with an interval" do
+      # Day precision on start
+      let(:cocina) { {"value" => "2004-02-01/2005", "encoding" => {"code" => "edtf"}} }
+
+      it "returns the precision of the calculated interval" do
+        expect(date.precision).to eq(:day)
+      end
+    end
+
+    context "with a year" do
+      let(:cocina) { {"value" => "2023", "encoding" => {"code" => "edtf"}} }
+
+      it "returns :year" do
+        expect(date.precision).to eq(:year)
+      end
+    end
+
+    context "with a month" do
+      let(:cocina) { {"value" => "2023-01", "encoding" => {"code" => "edtf"}} }
+
+      it "returns :month" do
+        expect(date.precision).to eq(:month)
+      end
+    end
+
+    context "with an unparsable date" do
+      let(:cocina) { {"value" => "invalid-date", "encoding" => {"code" => "edtf"}} }
+
+      it "returns :unknown" do
+        expect(date.precision).to eq(:unknown)
+      end
+    end
+  end
+
+  describe "#sort_key" do
+    let(:date_values) do
+      [
+        "2023-01-01",
+        "2023-01-02",
+        "2023",
+        "2022-10-30/2023-01-01",
+        "966",
+        "22",
+        "19xx",
+        "196x",
+        "0",
+        "-1",
+        "-35"
+      ]
+    end
+    let(:cocina_dates) { date_values.map { |v| {"value" => v, "encoding" => {"code" => "edtf"}} } }
+    let(:dates) { cocina_dates.map { |c| described_class.from_cocina(c) } }
+
+    it "sorts dates correctly" do
+      sorted_dates = dates.sort
+      expect(sorted_dates.map(&:value)).to eq([
+        "-35",
+        "-1",
+        "0",
+        "22",
+        "966",
+        "19xx",
+        "196x",
+        "2022-10-30/2023-01-01",
+        "2023",
+        "2023-01-01",
+        "2023-01-02"
+      ])
+    end
+  end
+
+  describe "#to_a" do
+    context "with a date range" do
+      let(:cocina) { {"value" => "2023-01-01/2023-01-31", "encoding" => {"code" => "edtf"}} }
+
+      it "returns the full range" do
+        expect(date.to_a).to eq((Date.parse("2023-01-01")..Date.parse("2023-01-31")).to_a)
+        expect(date.to_a.length).to eq(31)
+      end
+    end
+
+    context "with an EDTF::Set" do
+      let(:cocina) { {"value" => "[1991-01-01, 1992-02-01]", "encoding" => {"code" => "edtf"}} }
+
+      it "returns only the dates in the set" do
+        expect(date.to_a).to eq([Date.parse("1991-01-01"), Date.parse("1992-02-01")])
+        expect(date.to_a.length).to eq(2)
+      end
+    end
+  end
+
+  describe "#decoded_value" do
+    {
+      "-23" => "24 BCE",
+      "-1" => "2 BCE",
+      "0" => "1 BCE",
+      "1" => "1 CE",
+      "433" => "433 CE"
+    }.each do |value, expected|
+      context "with value #{value}" do
+        let(:cocina) { {"value" => value, "encoding" => {"code" => "edtf"}} }
+
+        it "returns #{expected}" do
+          expect(date.decoded_value).to eq(expected)
+        end
+      end
+    end
+
+    context "with a BCE century date" do
+      let(:cocina) { {"value" => "-0099", "encoding" => {"code" => "edtf"}} }
+
+      it "returns the century in BCE" do
+        expect(date.decoded_value(allowed_precisions: [:century])).to eq("2nd century BCE")
+      end
+    end
+
+    context "with date 2023-01-01" do
+      let(:cocina) { {"value" => "2023-01-01", "encoding" => {"code" => "edtf"}} }
+
+      [
+        ["2023-01-01", [:day], "January  1, 2023"],
+        ["2023-01-01", [:month], "January 2023"],
+        ["2023-01-01", [:year], "2023"],
+        ["2023-01-01", [:decade], "2020s"],
+        ["2023-01-01", [:century], "21st century"]
+      ].each do |value, allowed_precisions, expected|
+        context "with allowed precisions #{allowed_precisions}" do
+          it "returns #{expected}" do
+            expect(date.decoded_value(allowed_precisions: allowed_precisions)).to eq(expected)
+          end
+        end
+      end
+
+      context "with several allowed precisions" do
+        it "returns the most precise value" do
+          expect(date.decoded_value(allowed_precisions: [:day, :month, :year])).to eq("January  1, 2023")
+        end
+      end
+    end
+
+    context "with an unparsable date" do
+      let(:cocina) { {"value" => "invalid-date", "encoding" => {"code" => "edtf"}} }
+
+      it "returns the value unmodified" do
+        expect(date.decoded_value).to eq("invalid-date")
+      end
+
+      context "with ignore_unparseable true" do
+        it "returns nil" do
+          expect(date.decoded_value(ignore_unparseable: true)).to be_nil
+        end
+      end
+    end
+
+    context "with an unencoded date" do
+      let(:cocina) { {"value" => "about 933"} }
+
+      it "returns the value unmodified" do
+        expect(date.decoded_value).to eq("about 933")
+      end
+
+      context "with display_original_value false" do
+        it "returns the decoded value" do
+          expect(date.decoded_value(display_original_value: false)).to eq("933 CE")
+        end
+      end
+    end
+
+    context "with an interval" do
+      let(:cocina) { {"value" => "2023-01-01/2023-01-31", "encoding" => {"code" => "edtf"}} }
+
+      it "returns the decoded value as a date range" do
+        expect(date.decoded_value).to eq("January  1, 2023 - January 31, 2023")
+      end
+    end
+  end
+
+  describe "#qualified_value" do
+    context "with date 2023-01" do
+      let(:cocina) { {"value" => "2023-01", "qualifier" => qualifier, "encoding" => {"code" => "edtf"}} }
+
+      [
+        ["approximate", "[ca. January 2023]"],
+        ["questionable", "[January 2023?]"],
+        ["inferred", "[January 2023]"],
+        [nil, "January 2023"]
+      ].each do |qualifier_type, expected|
+        context "when the qualifier is #{qualifier_type || "not present"}" do
+          let(:qualifier) { qualifier_type }
+
+          it "returns #{expected}" do
+            expect(date.qualified_value).to eq(expected)
+          end
+        end
+      end
+    end
+  end
+
+  describe "ISO8601 encoded dates" do
+    {
+      "20131114161429" => Date.parse("20131114161429")..Date.parse("20131114161429")
+    }.each do |data, expected|
+      describe "with #{data}" do
+        let(:cocina) { {"value" => data, "encoding" => {"code" => "iso8601"}} }
+
+        it "has the range value #{expected}" do
+          expect(date.as_range.to_s).to eq expected.to_s
+        end
+      end
+    end
+  end
+
+  describe "W3CDTF encoded dates" do
+    {
+      "2013-08-00" => Date.parse("2013-08-01")..Date.parse("2013-08-31")
+    }.each do |data, expected|
+      describe "with #{data}" do
+        let(:cocina) { {"value" => data, "encoding" => {"code" => "w3cdtf"}} }
+
+        it "has the range value #{expected}" do
+          expect(date.as_range.to_s).to eq expected.to_s
+        end
+      end
+    end
+  end
+
+  describe "EDTF encoded dates" do
+    {
+      "1905" => Date.parse("1905-01-01")..Date.parse("1905-12-31"),
+      "190u" => Date.parse("1900-01-01")..Date.parse("1909-12-31"),
+      "190x" => Date.parse("1900-01-01")..Date.parse("1909-12-31"),
+      "19uu" => Date.parse("1900-01-01")..Date.parse("1999-12-31"),
+      "19xx" => Date.parse("1900-01-01")..Date.parse("1999-12-31"),
+      "1856/1876" => Date.parse("1856-01-01")..Date.parse("1876-12-31"),
+      "[1667,1668,1670..1672]" => Date.parse("1667-01-01")..Date.parse("1672-12-31"),
+      "1900-uu" => Date.parse("1900-01-01")..Date.parse("1900-12-31"),
+      "1900-uu-uu" => Date.parse("1900-01-01")..Date.parse("1900-12-31"),
+      "1900-uu-15" => Date.parse("1900-01-15")..Date.parse("1900-12-15"),
+      "1900-06-uu" => Date.parse("1900-06-01")..Date.parse("1900-06-30"),
+      "-250" => Date.parse("-250-01-01")..Date.parse("-250-12-31"), # EDTF requires a 4 digit year, but what can you do.
+      "63" => Date.parse("0063-01-01")..Date.parse("0063-12-31"),
+      "125" => Date.parse("125-01-01")..Date.parse("125-12-31"),
+      "1600-02" => "1600-02-01..1600-02-29"  # 1600 is a leap year; February has 29 days
+    }.each do |data, expected|
+      describe "with #{data}" do
+        let(:cocina) { {"value" => data, "encoding" => {"code" => "edtf"}} }
+
+        it "has the range value #{expected}" do
+          expect(date.as_range.to_s).to eq expected.to_s
+        end
+      end
+    end
+  end
+
+  describe "MARC encoded dates" do
+    {
+      "1234" => Date.parse("1234-01-01")..Date.parse("1234-12-31"),
+      "9999" => nil,
+      "1uuu" => Date.parse("1000-01-01")..Date.parse("1999-12-31"),
+      "||||" => nil
+    }.each do |data, expected|
+      describe "with #{data}" do
+        let(:cocina) { {"value" => data, "encoding" => {"code" => "marc"}} }
+
+        it "has the range value #{expected || "nil"}" do
+          expect(date.as_range.to_s).to eq expected.to_s
+        end
+      end
+    end
+  end
+
+  describe "M/D/Y dates" do
+    {
+      "11/27/2017" => Date.parse("2017-11-27")..Date.parse("2017-11-27"),
+      "5/27/2017" => Date.parse("2017-05-27")..Date.parse("2017-05-27"),
+      "5/2/2017" => Date.parse("2017-05-02")..Date.parse("2017-05-02"),
+      "12/1/2017" => Date.parse("2017-12-01")..Date.parse("2017-12-01"),
+      "12/1/17" => Date.parse("2017-12-01")..Date.parse("2017-12-01"),
+      "12/1/99" => Date.parse("1999-12-01")..Date.parse("1999-12-01"),
+      "6/18/938" => Date.parse("0938-06-18")..Date.parse("0938-06-18")
+    }.each do |data, expected|
+      describe "with #{data}" do
+        let(:cocina) { {"value" => data} }
+
+        it "has the range value #{expected}" do
+          expect(date.as_range.to_s).to eq expected.to_s
+        end
+      end
+    end
+  end
+
+  describe "Pulling out 4-digit years from unspecified dates" do
+    {
+      "Minguo 19 [1930]" => Date.parse("1930-01-01")..Date.parse("1930-12-31"),
+      "1745 mag. 14" => Date.parse("1745-01-01")..Date.parse("1745-12-31"),
+      "-745" => "", # too ambiguous to even attempt.
+      "-1999" => "", # too ambiguous to even attempt.
+      "[1923]" => Date.parse("1923-01-01")..Date.parse("1923-12-31"),
+      "1532." => Date.parse("1532-01-01")..Date.parse("1532-12-31"),
+      "[ca 1834]" => Date.parse("1834-01-01")..Date.parse("1834-12-31"),
+      "xvi" => Date.parse("1500-01-01")..Date.parse("1599-12-31"),
+      "cent. xvi" => Date.parse("1500-01-01")..Date.parse("1599-12-31"),
+      "MDLXXVIII" => Date.parse("1578-01-01")..Date.parse("1578-12-31"),
+      "[19--?]-" => Date.parse("1900-01-01")..Date.parse("1999-12-31"),
+      "19th Century" => Date.parse("1800-01-01")..Date.parse("1899-12-31"),
+      "19th c." => Date.parse("1800-01-01")..Date.parse("1899-12-31"),
+      "mid to 2nd half of 13th century" => Date.parse("1200-01-01")..Date.parse("1299-12-31"),
+      "167-?]" => Date.parse("1670-01-01")..Date.parse("1679-12-31"),
+      "189-?" => Date.parse("1890-01-01")..Date.parse("1899-12-31"),
+      "193-" => Date.parse("1930-01-01")..Date.parse("1939-12-31"),
+      "196_" => Date.parse("1960-01-01")..Date.parse("1969-12-31"),
+      "196x" => Date.parse("1960-01-01")..Date.parse("1969-12-31"),
+      "196u" => Date.parse("1960-01-01")..Date.parse("1969-12-31"),
+      "1960s" => Date.parse("1960-01-01")..Date.parse("1969-12-31"),
+      "186?" => Date.parse("1860-01-01")..Date.parse("1869-12-31"),
+      "1700?" => Date.parse("1700-01-01")..Date.parse("1700-12-31"),
+      "early 1730s" => Date.parse("1730-01-01")..Date.parse("1739-12-31"),
+      "[1670-1684]" => Date.parse("1670-01-01")..Date.parse("1684-12-31"),
+      "[18]74" => Date.parse("1874-01-01")..Date.parse("1874-12-31"),
+      "22" => Date.parse("0022-01-01")..Date.parse("0022-12-31"),
+      "223" => Date.parse("0223-01-01")..Date.parse("0223-12-31"),
+      "250 B.C." => Date.parse("-0249-01-01")..Date.parse("-249-12-31"),
+      "Anno M.DC.LXXXI." => Date.parse("1681-01-01")..Date.parse("1681-12-31"),
+      "624[1863 or 1864]" => Date.parse("1863-01-01")..Date.parse("1863-12-31"),
+      "chez Villeneuve" => nil,
+      "‏4264681 או 368" => nil
+    }.each do |data, expected|
+      describe "with #{data}" do
+        let(:cocina) { {"value" => data} }
+
+        it "has the range #{expected}" do
+          expect(date.as_range.to_s).to eq expected.to_s
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,14 @@
 # These have to come before importing any other code for coverage to work!
 require "simplecov"
 require "simplecov-rspec"
-SimpleCov.start do
-  add_filter "/spec/"
+
+# Ignore coverage if running a single file; otherwise turn it on
+if RSpec.configuration.files_to_run.count > 1
+  SimpleCov.start do
+    add_filter "/spec/"
+  end
+  SimpleCov::RSpec.start(list_uncovered_lines: true)
 end
-SimpleCov::RSpec.start(list_uncovered_lines: true)
 
 require "cocina_display"
 


### PR DESCRIPTION
Closes #6

This ports logic from both the mods gem (date parsing) and
stanford-mods gem (date formatting for display). A few tweaks
were made and tests added to get coverage to 100%.
