### PR TITLE
Loosen activesupport dependency pin to >= v7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cocina_display (0.4.0)
-      activesupport (~> 8.0, >= 8.0.2)
+      activesupport (>= 7)
       edtf (~> 3.2)
       janeway-jsonpath (~> 0.6)
 

--- a/cocina_display.gemspec
+++ b/cocina_display.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "janeway-jsonpath", "~> 0.6" # for nested JSON queries
-  spec.add_dependency "activesupport", "~> 8.0", ">= 8.0.2" # for helpers like present?
+  spec.add_dependency "activesupport", ">= 7" # for helpers like present?
   spec.add_dependency "edtf", "~> 3.2" # for parsing dates
 
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
This allows some Rails 7 apps to use the gem without upgrading.
