### PR TITLE
Support compacting records for ease of debugging

### DIFF
--- a/lib/cocina_display/utils.rb
+++ b/lib/cocina_display/utils.rb
@@ -45,5 +45,28 @@ module CocinaDisplay
 
       nested_values.flat_map { |node| flatten_nested_values(node, output) }
     end
+
+    # Recursively remove empty values from a hash, including nested hashes and arrays.
+    # @param hash [Hash] The hash to process
+    # @param output [Hash] Used for recursion, should be empty on first call
+    # @return [Hash] The hash with empty values removed
+    # @example
+    #  hash = { "name" => "", "age" => nil, "address => { "city" => "Anytown", "state" => [] } }
+    #  #  Utils.remove_empty_values(hash)
+    #  #=> { "address" => { "city" => "Anytown" } }
+    def self.deep_compact_blank(hash, output = {})
+      hash.each do |key, value|
+        if value.is_a?(Hash)
+          nested = deep_compact_blank(value)
+          output[key] = nested unless nested.empty?
+        elsif value.is_a?(Array)
+          compacted_array = value.map { |v| deep_compact_blank(v) }.reject(&:blank?)
+          output[key] = compacted_array unless compacted_array.empty?
+        elsif value.present?
+          output[key] = value
+        end
+      end
+      output
+    end
   end
 end

--- a/spec/cocina_record_spec.rb
+++ b/spec/cocina_record_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
   let(:cocina_json) { File.read(file_fixture("#{druid}.json")) }
   let(:cocina_doc) { JSON.parse(cocina_json) }
 
-  subject { described_class.new(cocina_json) }
+  subject { described_class.from_json(cocina_json) }
 
   describe "#content_type" do
     let(:druid) { "bx658jh7339" }

--- a/spec/concerns/access_spec.rb
+++ b/spec/concerns/access_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
   let(:cocina_json) { File.read(file_fixture("#{druid}.json")) }
   let(:cocina_doc) { JSON.parse(cocina_json) }
 
-  subject { described_class.new(cocina_json) }
+  subject { described_class.from_json(cocina_json) }
 
   describe "#purl_url" do
     let(:druid) { "bx658jh7339" }

--- a/spec/concerns/contributors_spec.rb
+++ b/spec/concerns/contributors_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       }
     }.to_json
   end
-  let(:record) { described_class.new(cocina_json) }
+  let(:record) { described_class.from_json(cocina_json) }
   let(:with_date) { false }
 
   describe "#main_author" do

--- a/spec/concerns/events_spec.rb
+++ b/spec/concerns/events_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       }
     }.to_json
   end
-  let(:record) { described_class.new(cocina_json) }
+  let(:record) { described_class.from_json(cocina_json) }
   let(:ignore_qualified) { false }
 
   describe "#pub_year_display_str" do

--- a/spec/concerns/forms_spec.rb
+++ b/spec/concerns/forms_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       }
     }.to_json
   end
-  let(:record) { described_class.new(cocina_json) }
+  let(:record) { described_class.from_json(cocina_json) }
 
   describe "#resource_types" do
     subject { record.resource_types }

--- a/spec/concerns/identifiers_spec.rb
+++ b/spec/concerns/identifiers_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
   let(:cocina_json) { File.read(file_fixture("#{druid}.json")) }
   let(:cocina_doc) { JSON.parse(cocina_json) }
 
-  subject { described_class.new(cocina_json) }
+  subject { described_class.from_json(cocina_json) }
 
   describe "#druid" do
     let(:druid) { "bx658jh7339" }

--- a/spec/concerns/subjects_spec.rb
+++ b/spec/concerns/subjects_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       }
     }.to_json
   end
-  let(:record) { described_class.new(cocina_json) }
+  let(:record) { described_class.from_json(cocina_json) }
 
   describe "#subject_topics" do
     subject { record.subject_topics }

--- a/spec/concerns/titles_spec.rb
+++ b/spec/concerns/titles_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       let(:cocina_json) { File.read(file_fixture("#{druid}.json")) }
       let(:cocina_doc) { JSON.parse(cocina_json) }
 
-      subject { described_class.new(cocina_json).main_title }
+      subject { described_class.from_json(cocina_json).main_title }
 
       context "with nonsorting characters" do
         let(:druid) { "bt553vr2845" }
@@ -40,7 +40,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       let(:cocina_json) { File.read(file_fixture("#{druid}.json")) }
       let(:cocina_doc) { JSON.parse(cocina_json) }
 
-      subject { described_class.new(cocina_json).full_title }
+      subject { described_class.from_json(cocina_json).full_title }
 
       context "with nonsorting characters" do
         let(:druid) { "bt553vr2845" }
@@ -65,7 +65,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       let(:cocina_json) { File.read(file_fixture("#{druid}.json")) }
       let(:cocina_doc) { JSON.parse(cocina_json) }
 
-      subject { described_class.new(cocina_json).display_title }
+      subject { described_class.from_json(cocina_json).display_title }
 
       context "with nonsorting characters" do
         let(:druid) { "bt553vr2845" }
@@ -90,7 +90,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       let(:cocina_json) { File.read(file_fixture("#{druid}.json")) }
       let(:cocina_doc) { JSON.parse(cocina_json) }
 
-      subject { described_class.new(cocina_json).sort_title }
+      subject { described_class.from_json(cocina_json).sort_title }
 
       context "with nonsorting characters" do
         let(:druid) { "bt553vr2845" }
@@ -115,7 +115,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       let(:cocina_json) { File.read(file_fixture("#{druid}.json")) }
       let(:cocina_doc) { JSON.parse(cocina_json) }
 
-      subject { described_class.new(cocina_json).additional_titles }
+      subject { described_class.from_json(cocina_json).additional_titles }
 
       context "with an alternative title" do
         let(:druid) { "nz187ct8959" }

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -88,4 +88,56 @@ RSpec.describe CocinaDisplay::Utils do
       end
     end
   end
+
+  describe "#deep_compact_blank" do
+    subject { described_class.deep_compact_blank(hash) }
+
+    context "with nested empty values" do
+      let(:hash) do
+        {
+          "name" => "John Doe",
+          "age" => nil,
+          "address" => {
+            "street" => "123 Main St",
+            "city" => "",
+            "state" => "CA"
+          },
+          "empty_array" => [],
+          "empty_hash" => {},
+          "nested_empty" => {
+            "key" => nil,
+            "another_empty" => []
+          }
+        }
+      end
+
+      it "removes keys with empty values" do
+        is_expected.to eq({
+          "name" => "John Doe",
+          "address" => {
+            "street" => "123 Main St",
+            "state" => "CA"
+          }
+        })
+      end
+    end
+
+    context "with no empty values" do
+      let(:hash) do
+        {
+          "name" => "John Doe",
+          "age" => 30,
+          "address" => {
+            "street" => "123 Main St",
+            "city" => "Anytown",
+            "state" => "CA"
+          }
+        }
+      end
+
+      it "returns the original hash" do
+        is_expected.to eq(hash)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds a helper utility to strip out empty values when loading
a record. A large portion of many records is just hash keys with
empty array values, which make it hard to read results and use up
space...this allows you to trim down the record when parsing in
development so things are easy to read and reason about.

Also separates the initializers for CocinaRecord so that it's
clear how to create one from JSON vs. from a hash.
