### PR TITLE
Simplify JSONPath wildcard selectors

### DIFF
--- a/lib/cocina_display/cocina_record.rb
+++ b/lib/cocina_display/cocina_record.rb
@@ -49,9 +49,9 @@ module CocinaDisplay
     # @param path_expression [String] The JSONPath expression to evaluate.
     # @see https://www.rubydoc.info/gems/janeway-jsonpath/0.6.0/file/README.md
     # @example Name values for contributors
-    #  record.path("$.description.contributor[*].name[*].value").search #=> ["Smith, John", "ACME Corp."]
+    #  record.path("$.description.contributor.*.name.*.value").search #=> ["Smith, John", "ACME Corp."]
     # @example Filtering nodes using a condition
-    #  record.path("$.description.contributor[?(@.type == 'person')].name[*].value").search #=> ["Smith, John"]
+    #  record.path("$.description.contributor[?(@.type == 'person')].name.*.value").search #=> ["Smith, John"]
     def path(path_expression)
       Janeway.enum_for(path_expression, cocina_doc)
     end
@@ -101,7 +101,7 @@ module CocinaDisplay
     #   puts file["size"] #=> 123456
     #  end
     def files
-      path("$.structural.contains[*].structural.contains[*]")
+      path("$.structural.contains.*.structural.contains[*]")
     end
   end
 end

--- a/lib/cocina_display/concerns/contributors.rb
+++ b/lib/cocina_display/concerns/contributors.rb
@@ -72,7 +72,7 @@ module CocinaDisplay
       # All contributors for the object, including authors, editors, etc.
       # @return [Array<Contributor>]
       def contributors
-        @contributors ||= path("$.description.contributor[*]").map { |c| Contributor.new(c) }
+        @contributors ||= path("$.description.contributor.*").map { |c| Contributor.new(c) }
       end
 
       # All contributors with a "creator" or "author" role.

--- a/lib/cocina_display/concerns/events.rb
+++ b/lib/cocina_display/concerns/events.rb
@@ -88,7 +88,7 @@ module CocinaDisplay
         filter_expr = type.present? ? "?match(@.type, \"#{type}\")" : "*"
 
         Enumerator::Chain.new(
-          path("$.description.event[*].date[#{filter_expr}]"),
+          path("$.description.event.*.date[#{filter_expr}]"),
           path("$.description.event[#{filter_expr}].date[*]")
         ).uniq.map do |date|
           CocinaDisplay::Dates::Date.from_cocina(date)

--- a/lib/cocina_display/concerns/forms.rb
+++ b/lib/cocina_display/concerns/forms.rb
@@ -108,13 +108,13 @@ module CocinaDisplay
       # Issuance terms for a work, drawn from the event notes.
       # @return [Array<String>]
       def issuance_terms
-        path("$.description.event[*].note[?@.type == 'issuance'].value").map(&:downcase).uniq
+        path("$.description.event.*.note[?@.type == 'issuance'].value").map(&:downcase).uniq
       end
 
       # Frequency terms for a periodical, drawn from the event notes.
       # @return [Array<String>]
       def frequency
-        path("$.description.event[*].note[?@.type == 'frequency'].value").map(&:downcase).uniq
+        path("$.description.event.*.note[?@.type == 'frequency'].value").map(&:downcase).uniq
       end
 
       # Values of the resource type form field prior to mapping.

--- a/lib/cocina_display/concerns/subjects.rb
+++ b/lib/cocina_display/concerns/subjects.rb
@@ -83,7 +83,7 @@ module CocinaDisplay
       def subjects
         @subjects ||= Enumerator::Chain.new(
           path("$.description.subject[*]"),
-          path("$.description.geographic[*].subject[*]")
+          path("$.description.geographic.*.subject[*]")
         ).map { |s| Subject.from_cocina(s) }
       end
     end

--- a/lib/cocina_display/imprint.rb
+++ b/lib/cocina_display/imprint.rb
@@ -67,7 +67,7 @@ module CocinaDisplay
     # The publisher information, combining all name values for publishers.
     # @return [String]
     def publisher_str
-      Utils.compact_and_join(Janeway.enum_for("$.contributor[?@.role[?@.value == 'publisher']].name[*].value", cocina), delimiter: " : ")
+      Utils.compact_and_join(Janeway.enum_for("$.contributor[?@.role[?@.value == 'publisher']].name.*.value", cocina), delimiter: " : ")
     end
 
     # Get the place name for a location, decoding from MARC if necessary.


### PR DESCRIPTION
This just uses a slightly more concise pattern for the JSONPath
wildcard selectors, to be more consistent with how we do other
property access. The brackets aren't needed unless you do another
access afterward that requires them.
