### PR TITLE
Add a script for crawling record and update the README

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,12 @@ GEM
     edtf (3.2.0)
       activesupport (>= 3.0, < 9.0)
     erb (5.0.1)
+    faraday (2.13.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -51,6 +57,8 @@ GEM
     lint_roller (1.1.0)
     logger (1.7.0)
     minitest (5.25.5)
+    net-http (0.6.0)
+      uri
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -62,6 +70,9 @@ GEM
     psych (5.2.6)
       date
       stringio
+    purl_fetcher-client (3.1.0)
+      activesupport
+      faraday (~> 2.1)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.0)
@@ -143,6 +154,7 @@ DEPENDENCIES
   cocina_display!
   debug (~> 1.11)
   irb
+  purl_fetcher-client (~> 3.1)
   rake (~> 13.0)
   rspec (~> 3.0)
   simplecov (~> 0.22.0)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ gem install cocina_display
 
 ### Obtaining Cocina
 
-To start, you need some Cocina in JSON form. 
+To start, you need some Cocina in JSON form. Consumers of this gem are likely to be applications that are already harvesting this data (for indexing) or have it stored in an index or database (for display). In testing, you may have neither of these.
 
 You can download some directly from PURL by visiting an object's PURL URL and appending `.json` to the end, like `https://purl.stanford.edu/bb112zx3193.json`. Some examples are available in the `spec/fixtures` directory.
 
-There is also a helper method to fetch the Cocina JSON for a given DRUID and immediately parse it into a `CocinaRecord` object:
+There is also a helper method to fetch the Cocina JSON for a given DRUID over HTTP and immediately parse it into a `CocinaRecord` object:
 
 ```ruby
 > record = CocinaDisplay::CocinaRecord.fetch('bb112zx3193')
@@ -51,7 +51,7 @@ The `CocinaRecord` class provides some methods to access common fields, as well 
 => "Hearst Magazines, Inc."
 ```
 
-See the [API Documentation](https://sul-dlss.github.io/cocina_display/CocinaDisplay/CocinaRecord.html) for more details on the methods available in the `CocinaRecord` class.
+See the [API Documentation](https://sul-dlss.github.io/cocina_display/CocinaDisplay/CocinaRecord.html) for more details on the methods available in the `CocinaRecord` class. The gem provides a large number of methods, organized into concerns, to access different parts of the data.
 
 ### Fetching nested data
 
@@ -61,47 +61,52 @@ The previous example used `Hash#dig` to access the first contributor's first nam
 
 ```ruby
 # name values for all contributors in description
-> record.path('$.description.contributor[*].name[*].value').search
+> record.path('$.description.contributor.*.name.*.value').search
 => ["Hearst Magazines, Inc.", "Chesebrough, Jerry"]
 # only contributors with a role with value "photographer"
-> record.path("$.description.contributor[?@.role[?@.value == 'photographer']].name[*].value").search
+> record.path("$.description.contributor[?@.role[?@.value == 'photographer']].name.*.value").search
 => ["Chesebrough, Jerry"]
 ```
 
 The JsonPath implementation used is [janeway](https://www.rubydoc.info/gems/janeway-jsonpath/0.6.0/file/README.md), which supports the full syntax from the [finalized 2024 version of the specification](https://www.rfc-editor.org/rfc/rfc9535.html). Results returned from `#path` are Enumerators.
 
-In the following example, we start an expression with `"$.."` to search for contributor nodes at _any_ level (e.g. `event.contributors`) and discover that there is a third contributor, but it has no `name` value. Using the `['code', 'value']` syntax, we can retrieve both `code` and `value` and show where they came from:
+In the following example, we start an expression with `"$.."` to search for contributor nodes at _any_ level (e.g. `event.contributors`) and discover that there is a third contributor, but it has no `name` value. Using the `['code', 'value']` syntax, we can retrieve both `code` and `value` and show the path they came from:
 
 ```ruby
-> record.path("$..contributor[*].name[*]['code', 'value']").each { |value, node, key| puts "#{key}: #{value} (from #{node})" }
-value: Hearst Magazines, Inc. (from {"structuredValue"=>[], "parallelValue"=>[], "groupedValue"=>[], "value"=>"Hearst Magazines, Inc.", "uri"=>"http://id.loc.gov/authorities/names/n2015050736", "identifier"=>[], "source"=>{"code"=>"naf", "uri"=>"http://id.loc.gov/authorities/names/", "note"=>[]}, "note"=>[], "appliesTo"=>[]})
-value: Chesebrough, Jerry (from {"structuredValue"=>[], "parallelValue"=>[], "groupedValue"=>[], "value"=>"Chesebrough, Jerry", "identifier"=>[], "note"=>[], "appliesTo"=>[]})
-code: CSt (from {"structuredValue"=>[], "parallelValue"=>[], "groupedValue"=>[], "code"=>"CSt", "uri"=>"http://id.loc.gov/vocabulary/organizations/cst", "identifier"=>[], "source"=>{"code"=>"marcorg", "uri"=>"http://id.loc.gov/vocabulary/organizations", "note"=>[]}, "note"=>[], "appliesTo"=>[]})
-=> ["Hearst Magazines, Inc.", "Chesebrough, Jerry", "CSt"]
+> record.path("$..contributor.*.name[*]['code', 'value']").map { |value, _node, key, path| [key, value, path] }
+[["value", "Hearst Magazines, Inc.", "$['description']['contributor'][0]['name'][0]['value']"],
+ ["value", "Chesebrough, Jerry", "$['description']['contributor'][1]['name'][0]['value']"],
+ ["code", "CSt", "$['description']['adminMetadata']['contributor'][0]['name'][0]['code']"]]
 ```
 
 There is also a command line utility for quickly querying a JSON file using JsonPath. Online syntax checkers may give different results, so it helps to test locally. You can run it with:
 
 ```bash
-cat spec/fixtures/bb112zx3193.json | janeway "$.description.contributor[?@.role[?@.value == 'photographer']].name[*].value"
+cat spec/fixtures/bb112zx3193.json | janeway "$.description.contributor[?@.role[?@.value == 'photographer']].name.*.value"
 [
   "Chesebrough, Jerry"
 ]
 ```
 
+### Searching for records
+
+Sometimes you need to determine if records exist "in the wild" that exhibit particular characteristics in the Cocina metadata, like the presence or absence of a field, or a specific value in a field. There is a template script in the `scripts/` directory that can be used to crawl all DRUIDs released to a particular target, like Searchworks, and examine each record.
+
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment. This is a useful place to try out JSONPath expressions with `CocinaRecord#path`.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+Tests are written using [rspec](https://rspec.info), with coverage automatically measured via [simplecov](https://github.com/simplecov-ruby/simplecov). CI will fail if coverage drops below 100%. For convenience, if you invoke a single spec file locally, coverage will not be reported.
 
-Documentation is generated using [yard](https://yardoc.org). You can generate it by running `yardoc`, or `yard server --reload` to start a local server and watch for changes as you edit.
+Documentation is generated using [yard](https://yardoc.org). You can generate it locally by running `yardoc`, or `yard server --reload` to start a local server and watch for changes as you edit. There is a GitHub action that automatically generates and publishes the documentation to GitHub Pages on every push/merge to `main`.
+
+To release a new version, update the version number in `version.rb`, run `bundle` to update `Gemfile.lock`, commit your changes, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Background
 
 Historically, applications at SUL used a combination of several gems to render objects represented by MODS XML. With the transition to the Cocina data model, infrastructure applications adopted the [cocina-models gem](https://github.com/sul-dlss/cocina-models), which provides accessor objects and validators over Cocina JSON. Internal applications can fetch such objects over HTTP using [dor-services-client](https://github.com/sul-dlss/dor-services-client).
 
-On the access side, Cocina JSON (the "public Cocina") is available statically via [PURL](https://purl.stanford.edu), but is only updated when an object is published ("shelved") from SDR. This frequently results in data that is technically invalid with respect to `cocina-models` but is still valid in the context of a patron-facing application.
+On the access side, Cocina JSON (the "public Cocina") is available statically via [PURL](https://purl.stanford.edu), but is only updated when an object is published ("shelved") from SDR. This frequently results in data that is technically invalid with respect to `cocina-models` (i.e. it does not match the latest spec) but is still valid in the context of a patron-facing application (because it can still be rendered into useful information).
 
 Cocina data can also be complex, representing the same underlying information in different ways. A "complete" implementation can involve checking multiple deeply nested paths to ensure no information is missed. Rather than tightly coupling access applications to `cocina-models`, this gem provides a set of helpers designed to safely parse Cocina JSON and render it in a consistent way across applications.
 

--- a/cocina_display.gemspec
+++ b/cocina_display.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov-rspec", "~> 0.4"
   spec.add_development_dependency "yard", "~> 0.9.37"
   spec.add_development_dependency "webrick", "~> 1.9", ">= 1.9.1" # for yard server
+  spec.add_development_dependency "purl_fetcher-client", "~> 3.1" # for find_records script
 end

--- a/script/find_records.rb
+++ b/script/find_records.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# This script is a simple, brute-force method for finding records that
+# exhibit certain characteristics in the public Cocina JSON for testing.
+#
+# It queries purl-fetcher for all DRUIDs released to a specific target and
+# then fetches each corresponding public Cocina record from PURL and examines it.
+#
+# You need to be on VPN to do this, as the purl-fetcher API is only accessible
+# from within the Stanford network.
+#
+# To use, modify any of the noted items below, then run:
+# $ bundle exec ruby script/find_records.rb
+#
+# You can exit early with Ctrl-C, and it will report how many records were
+# checked before exiting. Running through an entire target will take awhile,
+# on the order of 30 minutes or more.
+
+require "benchmark"
+require "pp"
+require "purl_fetcher/client"
+require "cocina_display"
+require "cocina_display/utils"
+
+# This should correspond to one of the release targets available in purl-fetcher,
+# i.e. "Searchworks", "Earthworks", etc.
+RELEASE_TARGET = "Searchworks"
+
+# Modify this expression to match the JSON path you want to search, or just
+# modify the `examine_record` method directly.
+PATH_EXPR = "$..[?length(@.groupedValue) > 0]"
+
+# Modify this method as needed to change what you're looking for in each record.
+# It takes a CocinaRecord object and should return an array of [path, result] pairs.
+def examine_record(record)
+  record.path(PATH_EXPR).map { |value, _node, _key, path| [path, CocinaDisplay::Utils.deep_compact_blank(value)] }
+end
+
+# Track total records in target and how many we've seen
+released_to_target = []
+processed_records = 0
+
+# Handle Ctrl-C gracefully
+Signal.trap("INT") do
+  puts "\nExiting after processing #{processed_records} records."
+  exit
+end
+
+# Fetch everything from purl-fetcher; note that this is one single HTTP request
+# that returns a massive JSON response – it can be quite slow
+puts "Finding records released to #{RELEASE_TARGET}..."
+client = PurlFetcher::Client::Reader.new
+query_time = Benchmark.realtime do
+  client.released_to(RELEASE_TARGET).each do |record|
+    released_to_target << record["druid"].delete_prefix("druid:")
+  end
+rescue Faraday::ConnectionFailed => e
+  puts "Connection failed: #{e.message}; are you on VPN?"
+  exit 1
+end
+puts "Found #{released_to_target.size} records released to #{RELEASE_TARGET} in #{query_time.round(2)} seconds"
+
+# Iterate through the list of DRUIDs and fetch each one from PURL, creating a
+# CocinaRecord object. Then call our examine_record method on it and if
+# anything was returned, print the DRUID and the results.
+released_to_target.each do |druid|
+  begin
+    cocina_record = CocinaDisplay::CocinaRecord.fetch(druid)
+    processed_records += 1
+  rescue => e
+    puts "Error fetching record #{druid}: #{e.message}"
+    next
+  end
+
+  results = examine_record(cocina_record)
+  next if results.empty?
+
+  puts "Druid: #{druid}"
+  results.each do |path, result|
+    puts "  Path: #{path}"
+    puts "  Result: #{result.pretty_inspect}\n"
+  end
+
+  puts "-" * 80
+end


### PR DESCRIPTION
This adds a helper script to find records "in the wild" that
exhibit particular characteristics, which is useful in development.

Also substantially updates and expands the README.
