### PR TITLE
Fix sort_title for titles with punctuation surrounded by spaces

### DIFF
--- a/lib/cocina_display/title_builder.rb
+++ b/lib/cocina_display/title_builder.rb
@@ -53,7 +53,7 @@ module CocinaDisplay
     def self.sort_title(titles, catalog_links: [])
       part_label = catalog_links.find { |link| link["catalog"] == "folio" }&.fetch("partLabel", nil)
       [new(strategy: :first, add_punctuation: false, only_one_parallel_value: false, part_label: part_label, sortable: true).build(titles)]
-        .flatten.compact.map { |title| title.gsub(/[[:punct:]]*/, "").strip }
+        .flatten.compact.map { |title| title.gsub(/[[:punct:]]*/, "").squeeze(" ").strip }
     end
 
     # @param strategy [Symbol] ":first" selects a single title value based on precedence of

--- a/spec/concerns/titles_spec.rb
+++ b/spec/concerns/titles_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe CocinaDisplay::CocinaRecord do
           is_expected.to eq "M de Courville estampe"
         end
       end
+
+      context "with a title containing punctuation surrounded by spaces" do
+        let(:druid) { "vk217bh4910" }
+
+        it "returns the sort title without duplicate spaces" do
+          is_expected.to eq "2010 Machine Learning Data Set for NASAs Solar Dynamics Observatory Atmospheric Imaging Assembly"
+        end
+      end
     end
 
     context "with no title" do


### PR DESCRIPTION
This is the solution stanford-mods uses to address this: https://github.com/sul-dlss/stanford-mods/blob/eb4392be6817078737daaf3cb0b6362145cd921f/lib/stanford-mods/concerns/title.rb#L75