### PR TITLE
Make contributor methods consider event contributors

### DIFF
--- a/lib/cocina_display/concerns/contributors.rb
+++ b/lib/cocina_display/concerns/contributors.rb
@@ -79,9 +79,13 @@ module CocinaDisplay
       end
 
       # All contributors for the object, including authors, editors, etc.
+      # Checks both description.contributor and description.event.contributor.
       # @return [Array<Contributor>]
       def contributors
-        @contributors ||= path("$.description.contributor.*").map { |c| Contributor.new(c) }
+        @contributors ||= Enumerator::Chain.new(
+          path("$.description.contributor.*"),
+          path("$.description.event.*.contributor.*")
+        ).map { |c| Contributor.new(c) }
       end
 
       # All contributors with a "publisher" role.

--- a/spec/concerns/contributors_spec.rb
+++ b/spec/concerns/contributors_spec.rb
@@ -413,5 +413,29 @@ RSpec.describe CocinaDisplay::CocinaRecord do
 
       it { is_expected.to be_empty }
     end
+
+    context "with publication event contributors" do
+      let(:cocina_json) do
+        {
+          "description" => {
+            "event" => [
+              {
+                "type" => "publication",
+                "contributor" => [
+                  {
+                    "name" => [{"value" => "Chronicle Books"}],
+                    "role" => [{"value" => "publisher"}]
+                  }
+                ]
+              }
+            ]
+          }
+        }.to_json
+      end
+
+      it "returns the publisher from the event" do
+        is_expected.to eq(["Chronicle Books"])
+      end
+    end
   end
 end


### PR DESCRIPTION
Contributors can be present at description.contributors or at
description.event.contributors.

Fixes #49
