### PR TITLE
Add support for querying place-type subjects

### DIFF
--- a/lib/cocina_display/concerns/subjects.rb
+++ b/lib/cocina_display/concerns/subjects.rb
@@ -35,6 +35,12 @@ module CocinaDisplay
         subject_values.filter { |s| s.type == "occupation" }.map(&:display_str).uniq
       end
 
+      # All unique subject values that describe geographic places.
+      # @return [Array<String>]
+      def subject_places
+        subject_values.filter(&:place?).map(&:display_str).uniq
+      end
+
       # All unique subject values that are names of entities.
       # @note Multiple types are handled: person, family, organization, conference, etc.
       # @see CocinaDisplay::NameSubjectValue
@@ -46,9 +52,10 @@ module CocinaDisplay
       # Combination of all subject values for searching.
       # @see #subject_topics_other
       # @see #subject_temporal_genre
+      # @see #subject_places
       # @return [Array<String>]
       def subject_all
-        subject_topics_other + subject_temporal_genre
+        subject_topics_other + subject_temporal_genre + subject_places
       end
 
       # Combination of topic, occupation, name, and title subject values for searching.

--- a/lib/cocina_display/subjects/subject_value.rb
+++ b/lib/cocina_display/subjects/subject_value.rb
@@ -39,6 +39,13 @@ module CocinaDisplay
       def display_str
         cocina["value"]
       end
+
+      # True if the subject value is a place.
+      # @see PLACE_SUBJECT_TYPES
+      # @return [Boolean]
+      def place?
+        PLACE_SUBJECT_TYPES.include?(type)
+      end
     end
 
     # A subject value representing a named entity.
@@ -102,3 +109,20 @@ SUBJECT_VALUE_TYPES = {
   # TODO: special handling for geospatial subjects
   # "map coordinates", "bounding box coordinates", "point coordinates"
 }.freeze
+
+# Subject types that are considered places.
+PLACE_SUBJECT_TYPES = [
+  "area",
+  "city",
+  "city section",
+  "continent",
+  "country",
+  "county",
+  "coverage",
+  "extraterrestrial area",
+  "island",
+  "place",
+  "region",
+  "state",
+  "territory"
+].freeze

--- a/spec/concerns/subjects_spec.rb
+++ b/spec/concerns/subjects_spec.rb
@@ -282,6 +282,65 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     end
   end
 
+  describe "#subject_places" do
+    subject { record.subject_places }
+
+    context "with non-structured place subjects" do
+      let(:subjects) do
+        [
+          {"type" => "place", "value" => "California"}
+        ]
+      end
+
+      it "returns the value as a string" do
+        is_expected.to eq(["California"])
+      end
+    end
+
+    context "with structured place subjects" do
+      let(:subjects) do
+        [
+          {
+            "structuredValue" => [
+              {"value" => "Germany", "type" => "country"},
+              {"value" => "Leipzig", "type" => "city"}
+            ],
+            "type" => "place"
+          }
+        ]
+      end
+
+      it "returns the values separately" do
+        is_expected.to eq(["Germany", "Leipzig"])
+      end
+    end
+
+    context "with nested structured place subjects" do
+      let(:subjects) do
+        [
+          {
+            "structuredValue" => [
+              {
+                "type" => "place",
+                "structuredValue" => [
+                  {"value" => "Paris", "type" => "city"},
+                  {"value" => "France", "type" => "country"}
+                ]
+              },
+              {"value" => "Eiffel Tower"},
+              {"value" => "Construction"}
+            ],
+            "type" => "topic"
+          }
+        ]
+      end
+
+      it "returns the place values separately" do
+        is_expected.to eq(["Paris", "France"])
+      end
+    end
+  end
+
   describe "faceting methods" do
     let(:subjects) do
       [
@@ -290,14 +349,15 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         {"type" => "title", "value" => "The Great Gatsby"},
         {"type" => "genre", "value" => "Fiction"},
         {"type" => "time", "value" => "2020"},
-        {"type" => "name", "value" => "John Doe"}
+        {"type" => "name", "value" => "John Doe"},
+        {"type" => "place", "value" => "California"}
       ]
     end
     describe "#subject_all" do
       subject { record.subject_all }
 
       it "combines all subject facets" do
-        is_expected.to eq(["Climate change", "Software Engineer", "John Doe", "The Great Gatsby", "2020", "Fiction"])
+        is_expected.to eq(["Climate change", "Software Engineer", "John Doe", "The Great Gatsby", "2020", "Fiction", "California"])
       end
     end
 


### PR DESCRIPTION
Ref #15

This covers the stanford-mods 'geographic_search'/'geographic_facet'
and 'subject_all_search' methods.

I elected not to name the method 'geographic' because that seemed
confusing when there are other subject types that involve actual
GIS information (coordinates, points, etc.) and these methods really
just return place names (strings).
