### PR TITLE
Update deep_compact_blank to handle compacting arrays

### DIFF
--- a/lib/cocina_display/utils.rb
+++ b/lib/cocina_display/utils.rb
@@ -56,8 +56,10 @@ module CocinaDisplay
     #  hash = { "name" => "", "age" => nil, "address => { "city" => "Anytown", "state" => [] } }
     #  #  Utils.remove_empty_values(hash)
     #  #=> { "address" => { "city" => "Anytown" } }
-    def self.deep_compact_blank(hash, output = {})
-      hash.each do |key, value|
+    def self.deep_compact_blank(node, output = {})
+      return node unless node.is_a?(Hash)
+
+      node.each do |key, value|
         if value.is_a?(Hash)
           nested = deep_compact_blank(value)
           output[key] = nested unless nested.empty?
@@ -68,6 +70,7 @@ module CocinaDisplay
           output[key] = value
         end
       end
+
       output
     end
   end

--- a/script/deep_compact.rb
+++ b/script/deep_compact.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Given a JSON data structure from stdin, recursively remove empty keys and
+# blank values to create a more compact representation and write to stdout.
+
+require "json"
+
+require_relative "../lib/cocina_display/utils"
+
+input = $stdin.read
+data = JSON.parse(input)
+compact_data = CocinaDisplay::Utils.deep_compact_blank(data)
+$stdout.puts JSON.generate(compact_data)

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -154,6 +154,29 @@ RSpec.describe CocinaDisplay::Utils do
       end
     end
 
+    context "with arrays containing empty values" do
+      let(:hash) do
+        {
+          "tags" => ["tag1", "", nil, "tag2"],
+          "comments" => [
+            {"author" => "Alice", "text" => "Great post!"},
+            {"author" => "", "text" => ""},
+            {"author" => "Bob", "text" => nil}
+          ]
+        }
+      end
+
+      it "removes empty values from arrays" do
+        is_expected.to eq({
+          "tags" => ["tag1", "tag2"],
+          "comments" => [
+            {"author" => "Alice", "text" => "Great post!"},
+            {"author" => "Bob"}
+          ]
+        })
+      end
+    end
+
     context "with no empty values" do
       let(:hash) do
         {


### PR DESCRIPTION
This addresses a bug I found while investigating
https://github.com/sul-dlss/purl-fetcher/issues/1022.

Also adds a small convenience script for compacting a local JSON
file that I used to compare the sizes of files.
