### PR TITLE
Prevent errors for some cases of really wack coordinates

### DIFF
--- a/lib/cocina_display/geospatial.rb
+++ b/lib/cocina_display/geospatial.rb
@@ -258,7 +258,7 @@ module CocinaDisplay
         # @return [String]
         def normalize_coord(coord_str)
           matches = coord_str.match(self::POINT_PATTERN)
-          return if matches.size == 0
+          return unless matches
 
           hem = matches[:hem]
           deg = matches[:deg].to_i
@@ -277,7 +277,7 @@ module CocinaDisplay
       # @return [Point, nil]
       def self.parse(input_str)
         matches = input_str.match(self::PATTERN)
-        return if matches.size == 0
+        return unless matches
 
         lat = normalize_coord(matches[:lat])
         lng = normalize_coord(matches[:lng])
@@ -293,7 +293,7 @@ module CocinaDisplay
       # @return [BoundingBox, nil]
       def self.parse(input_str)
         matches = input_str.match(self::PATTERN)
-        return if matches.size == 0
+        return unless matches
 
         min_lng = normalize_coord(matches[:min_lng])
         max_lng = normalize_coord(matches[:max_lng])

--- a/spec/concerns/geospatial_spec.rb
+++ b/spec/concerns/geospatial_spec.rb
@@ -331,6 +331,29 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         end
       end
 
+      # Arguably bad data, but it is possible to parse correctly as-is.
+      context "with DMS coordinates and scale from MARC 034" do
+        # druid:vd002bm9939
+        let(:coordinates) { "$b3100000W 120°00′00″--W 114°00′00″/N 042°00′00″--N 036°00′00″" }
+
+        it "parses and formats correctly" do
+          is_expected.to eq("120°00′00″W -- 114°00′00″W / 42°00′00″N -- 36°00′00″N")
+        end
+      end
+
+      # NOTE: this is a pathological case where the $b scale info got turned into
+      # a fake DMS coordinate and the real coordinate is left at the end.
+      # There are potentially hundreds of these, but we're going to remediate them
+      # instead of attempting to be smart about the parsing.
+      context "with a poorly parsed MARC 034" do
+        # druid:sw279br4627
+        let(:coordinates) { "b 164°18′36″--W 047°40′00″/W 031°40′00″--N 066°00′00″$gN0590800" }
+
+        it "returns the original string" do
+          is_expected.to eq("b 164°18′36″--W 047°40′00″/W 031°40′00″--N 066°00′00″$gN0590800")
+        end
+      end
+
       context "with a single point in decimal degrees" do
         # druid:sb789ym1480
         let(:coordinates) { "41.891797, 12.486419" }


### PR DESCRIPTION
There was an error path where the overall regex matched the
string, but the individual coordinates inside it couldn't be
parsed. This fixes that and adds some tests with (real)
pathological data.
