### PR TITLE
Rename '#display_str' to use #to_s and simplify names

### DIFF
--- a/lib/cocina_display/concerns/contributors.rb
+++ b/lib/cocina_display/concerns/contributors.rb
@@ -62,8 +62,8 @@ module CocinaDisplay
       def contributor_names_by_role(with_date: false)
         contributors.each_with_object({}) do |contributor, hash|
           contributor.roles.each do |role|
-            hash[role.display_str] ||= []
-            hash[role.display_str] << contributor.display_name(with_date: with_date)
+            hash[role.to_s] ||= []
+            hash[role.to_s] << contributor.display_name(with_date: with_date)
           end
         end
       end

--- a/lib/cocina_display/concerns/events.rb
+++ b/lib/cocina_display/concerns/events.rb
@@ -62,8 +62,8 @@ module CocinaDisplay
       # @param ignore_qualified [Boolean] Reject qualified dates (e.g. approximate)
       # @return [String, nil]
       # @example Year range
-      #  CocinaRecord.fetch('bb099mt5053').pub_year_display_str #=> "1932 - 2012"
-      def pub_year_display_str(ignore_qualified: false)
+      #  CocinaRecord.fetch('bb099mt5053').pub_year_str #=> "1932 - 2012"
+      def pub_year_str(ignore_qualified: false)
         date = pub_date(ignore_qualified: ignore_qualified)
         return unless date
 
@@ -72,18 +72,18 @@ module CocinaDisplay
 
       # String for displaying the imprint statement(s).
       # @return [String, nil]
-      # @see CocinaDisplay::Imprint#display_str
+      # @see CocinaDisplay::Imprint#to_s
       # @example
-      #   CocinaRecord.fetch('bt553vr2845').imprint_display_str #=> "New York : Meridian Book, 1993, c1967"
-      def imprint_display_str
-        imprint_events.map(&:display_str).compact_blank.join("; ")
+      #   CocinaRecord.fetch('bt553vr2845').imprint_str #=> "New York : Meridian Book, 1993, c1967"
+      def imprint_str
+        imprint_events.map(&:to_s).compact_blank.join("; ")
       end
 
       # List of places of publication as strings.
       # Considers locations for all publication, creation, and capture events.
       # @return [Array<String>]
       def publication_places
-        publication_events.flat_map { |event| event.locations.map(&:display_str) }
+        publication_events.flat_map { |event| event.locations.map(&:to_s) }
       end
 
       # All events associated with the object.

--- a/lib/cocina_display/concerns/geospatial.rb
+++ b/lib/cocina_display/concerns/geospatial.rb
@@ -10,7 +10,7 @@ module CocinaDisplay
       # @return [Array<String>]
       # @example ["34°03′08″N 118°14′37″W"]
       def coordinates
-        coordinate_subjects.map(&:display_str).compact.uniq
+        coordinate_subjects.map(&:to_s).compact.uniq
       end
 
       # All valid coordinate data formatted for indexing into a Solr RPT field.

--- a/lib/cocina_display/concerns/languages.rb
+++ b/lib/cocina_display/concerns/languages.rb
@@ -13,7 +13,7 @@ module CocinaDisplay
       # Names of languages associated with the object, if recognized by Searchworks.
       # @return [Array<String>]
       def searchworks_language_names
-        languages.filter_map { |lang| lang.display_str if lang.searchworks_language? }.compact_blank.uniq
+        languages.filter_map { |lang| lang.to_s if lang.searchworks_language? }.compact_blank.uniq
       end
     end
   end

--- a/lib/cocina_display/concerns/subjects.rb
+++ b/lib/cocina_display/concerns/subjects.rb
@@ -8,37 +8,37 @@ module CocinaDisplay
       # All unique subject values that are topics.
       # @return [Array<String>]
       def subject_topics
-        subject_values.filter { |s| s.type == "topic" }.map(&:display_str).uniq
+        subject_values.filter { |s| s.type == "topic" }.map(&:to_s).uniq
       end
 
       # All unique subject values that are genres.
       # @return [Array<String>]
       def subject_genres
-        subject_values.filter { |s| s.type == "genre" }.map(&:display_str).uniq
+        subject_values.filter { |s| s.type == "genre" }.map(&:to_s).uniq
       end
 
       # All unique subject values that are titles.
       # @return [Array<String>]
       def subject_titles
-        subject_values.filter { |s| s.type == "title" }.map(&:display_str).uniq
+        subject_values.filter { |s| s.type == "title" }.map(&:to_s).uniq
       end
 
       # All unique subject values that are date/time info.
       # @return [Array<String>]
       def subject_temporal
-        subject_values.filter { |s| s.type == "time" }.map(&:display_str).uniq
+        subject_values.filter { |s| s.type == "time" }.map(&:to_s).uniq
       end
 
       # All unique subject values that are occupations.
       # @return [Array<String>]
       def subject_occupations
-        subject_values.filter { |s| s.type == "occupation" }.map(&:display_str).uniq
+        subject_values.filter { |s| s.type == "occupation" }.map(&:to_s).uniq
       end
 
       # All unique subject values that are named geographic places.
       # @return [Array<String>]
       def subject_places
-        place_subject_values.map(&:display_str).uniq
+        place_subject_values.map(&:to_s).uniq
       end
 
       # All unique subject values that are names of entities.
@@ -46,7 +46,7 @@ module CocinaDisplay
       # @see CocinaDisplay::NameSubjectValue
       # @return [Array<String>]
       def subject_names
-        subject_values.filter { |s| s.is_a? CocinaDisplay::Subjects::NameSubjectValue }.map(&:display_str).uniq
+        subject_values.filter { |s| s.is_a? CocinaDisplay::Subjects::NameSubjectValue }.map(&:to_s).uniq
       end
 
       # Combination of all subject values for searching.
@@ -84,10 +84,10 @@ module CocinaDisplay
       end
 
       # Combination of all subjects with nested values concatenated for display.
-      # @see Subject#display_str
+      # @see Subject#to_s
       # @return [Array<String>]
       def subject_all_display
-        subjects.map(&:display_str).uniq
+        subjects.map(&:to_s).uniq
       end
 
       private

--- a/lib/cocina_display/contributors/contributor.rb
+++ b/lib/cocina_display/contributors/contributor.rb
@@ -74,14 +74,14 @@ module CocinaDisplay
       # @param with_date [Boolean] Include life dates, if present
       # @return [String]
       def display_name(with_date: false)
-        names.map { |name| name.display_str(with_date: with_date) }.first
+        names.map { |name| name.to_s(with_date: with_date) }.first
       end
 
       # A string representation of the contributor's roles, formatted for display.
       # If there are multiple roles, they are joined with commas.
       # @return [String]
       def display_role
-        roles.map(&:display_str).to_sentence
+        roles.map(&:to_s).to_sentence
       end
 
       # All names in the Cocina as Name objects.

--- a/lib/cocina_display/contributors/name.rb
+++ b/lib/cocina_display/contributors/name.rb
@@ -22,10 +22,10 @@ module CocinaDisplay
       # @param with_date [Boolean] Include life dates, if present
       # @return [String]
       # @example no dates
-      #   name.display_name # => "King, Martin Luther, Jr."
+      #   name.to_s # => "King, Martin Luther, Jr."
       # @example with dates
-      #   name.display_name(with_date: true) # => "King, Martin Luther, Jr., 1929-1968"
-      def display_str(with_date: false)
+      #   name.to_s(with_date: true) # => "King, Martin Luther, Jr., 1929-1968"
+      def to_s(with_date: false)
         if cocina["value"].present?
           cocina["value"]
         elsif display_name_str.present?

--- a/lib/cocina_display/contributors/role.rb
+++ b/lib/cocina_display/contributors/role.rb
@@ -17,7 +17,7 @@ module CocinaDisplay
       # The name of the role.
       # Translates the MARC relator code if no value was present.
       # @return [String, nil]
-      def display_str
+      def to_s
         cocina["value"] || (Vocabularies::MARC_RELATOR[code] if marc_relator?)
       end
 
@@ -30,13 +30,13 @@ module CocinaDisplay
       # Does this role indicate the contributor is an author?
       # @return [Boolean]
       def author?
-        display_str =~ /^(author|creator)/i
+        to_s =~ /^(author|creator)/i
       end
 
       # Does this role indicate the contributor is a publisher?
       # @return [Boolean]
       def publisher?
-        display_str =~ /^publisher/i
+        to_s =~ /^publisher/i
       end
 
       private

--- a/lib/cocina_display/events/imprint.rb
+++ b/lib/cocina_display/events/imprint.rb
@@ -16,7 +16,7 @@ module CocinaDisplay
     class Imprint < Event
       # The entire imprint statement formatted as a string for display.
       # @return [String]
-      def display_str
+      def to_s
         place_pub = Utils.compact_and_join([place_str, publisher_str], delimiter: " : ")
         edition_place_pub = Utils.compact_and_join([edition_str, place_pub], delimiter: " - ")
         Utils.compact_and_join([edition_place_pub, date_str], delimiter: ", ")
@@ -93,7 +93,7 @@ module CocinaDisplay
       def locations_for_display
         unencoded_locs, encoded_locs = locations.partition { |loc| loc.unencoded_value? }
         locs_for_display = unencoded_locs.presence || encoded_locs
-        locs_for_display.map(&:display_str).compact_blank.uniq
+        locs_for_display.map(&:to_s).compact_blank.uniq
       end
     end
   end

--- a/lib/cocina_display/events/location.rb
+++ b/lib/cocina_display/events/location.rb
@@ -15,7 +15,7 @@ module CocinaDisplay
       # The name of the location.
       # Decodes a MARC country code if present and no value was present.
       # @return [String, nil]
-      def display_str
+      def to_s
         cocina["value"] || decoded_country
       end
 

--- a/lib/cocina_display/language.rb
+++ b/lib/cocina_display/language.rb
@@ -14,7 +14,7 @@ module CocinaDisplay
 
     # The language name for display.
     # @return [String, nil]
-    def display_str
+    def to_s
       cocina["value"] || decoded_value
     end
 
@@ -34,7 +34,7 @@ module CocinaDisplay
     # @see CocinaDisplay::Vocabularies::SEARCHWORKS_LANGUAGES
     # @return [Boolean]
     def searchworks_language?
-      Vocabularies::SEARCHWORKS_LANGUAGES.value?(display_str)
+      Vocabularies::SEARCHWORKS_LANGUAGES.value?(to_s)
     end
 
     # True if the language has a code sourced from the ISO 639 vocabulary.

--- a/lib/cocina_display/subjects/subject.rb
+++ b/lib/cocina_display/subjects/subject.rb
@@ -24,12 +24,12 @@ module CocinaDisplay
       # Used for search, where each value should be indexed separately.
       # @return [Array<String>]
       def display_values
-        subject_values.map(&:display_str).compact_blank
+        subject_values.map(&:to_s).compact_blank
       end
 
       # A string representation of the entire subject, concatenated for display.
       # @return [String]
-      def display_str
+      def to_s
         Utils.compact_and_join(display_values, delimiter: " > ")
       end
 

--- a/lib/cocina_display/subjects/subject_value.rb
+++ b/lib/cocina_display/subjects/subject_value.rb
@@ -39,7 +39,7 @@ module CocinaDisplay
       # The display string for the subject value.
       # Subclasses should override this method to provide specific formatting.
       # @return [String]
-      def display_str
+      def to_s
         cocina["value"]
       end
     end
@@ -57,9 +57,9 @@ module CocinaDisplay
 
       # Use the contributor name formatting rules for display.
       # @return [String] The formatted name string, including life dates
-      # @see CocinaDisplay::Contributor::Name#display_str
-      def display_str
-        @name.display_str(with_date: true)
+      # @see CocinaDisplay::Contributor::Name#to_s
+      def to_s
+        name.to_s(with_date: true)
       end
     end
 
@@ -69,7 +69,7 @@ module CocinaDisplay
       # @see CocinaDisplay::TitleBuilder.build
       # @note Unclear how often structured title subjects occur "in the wild".
       # @return [String]
-      def display_str
+      def to_s
         TitleBuilder.build([cocina])
       end
     end
@@ -84,7 +84,7 @@ module CocinaDisplay
       end
 
       # @return [String] The formatted date/time string for display
-      def display_str
+      def to_s
         date.qualified_value
       end
     end
@@ -122,7 +122,7 @@ module CocinaDisplay
       # The normalized DMS string for the coordinates.
       # Falls back to the raw value if parsing fails.
       # @return [String, nil]
-      def display_str
+      def to_s
         coordinates&.to_s || super
       end
     end

--- a/spec/concerns/events_spec.rb
+++ b/spec/concerns/events_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe CocinaDisplay::CocinaRecord do
   let(:record) { described_class.from_json(cocina_json) }
   let(:ignore_qualified) { false }
 
-  describe "#pub_year_display_str" do
-    subject { record.pub_year_display_str(ignore_qualified: ignore_qualified) }
+  describe "#pub_year_str" do
+    subject { record.pub_year_str(ignore_qualified: ignore_qualified) }
 
     context "when there are no dates" do
       it { is_expected.to be_nil }
@@ -305,8 +305,8 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     end
   end
 
-  describe "#imprint_display_str" do
-    subject { record.imprint_display_str }
+  describe "#imprint_str" do
+    subject { record.imprint_str }
 
     let(:cocina_json) do
       {

--- a/spec/imprint_spec.rb
+++ b/spec/imprint_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 require_relative "../lib/cocina_display/events/imprint"
 
 RSpec.describe CocinaDisplay::Events::Imprint do
-  subject { described_class.new(cocina).display_str }
+  subject { described_class.new(cocina).to_s }
 
   describe "date processing" do
     context "with values marked as unparsable" do


### PR DESCRIPTION
Close #57

This also led to shortening a few names that felt redundant, like
imprint_display_str just becoming imprint_str (the only reason we
make a string is for display).

Should also lead to a few more intuitive consequences like better
debugging output because #to_s can be called implicitly.
