### PR TITLE
Add helper methods for structural metadata

### DIFF
--- a/lib/cocina_display/cocina_record.rb
+++ b/lib/cocina_display/cocina_record.rb
@@ -16,6 +16,7 @@ require_relative "concerns/subjects"
 require_relative "concerns/forms"
 require_relative "concerns/languages"
 require_relative "concerns/geospatial"
+require_relative "concerns/structural"
 require_relative "utils"
 
 module CocinaDisplay
@@ -30,6 +31,7 @@ module CocinaDisplay
     include CocinaDisplay::Concerns::Forms
     include CocinaDisplay::Concerns::Languages
     include CocinaDisplay::Concerns::Geospatial
+    include CocinaDisplay::Concerns::Structural
 
     # Fetch a public Cocina document from PURL and create a CocinaRecord.
     # @note This is intended to be used in development or testing only.
@@ -107,18 +109,6 @@ module CocinaDisplay
     # @return [Boolean]
     def collection?
       content_type == "collection"
-    end
-
-    # Traverse nested FileSets and return an enumerator over their files.
-    # Each file is a +Hash+.
-    # @return [Enumerator] Enumerator over file hashes
-    # @example
-    #  record.files.each do |file|
-    #   puts file["filename"] #=> "image1.jpg"
-    #   puts file["size"] #=> 123456
-    #  end
-    def files
-      path("$.structural.contains.*.structural.contains[*]")
     end
   end
 end

--- a/lib/cocina_display/concerns/structural.rb
+++ b/lib/cocina_display/concerns/structural.rb
@@ -1,0 +1,41 @@
+require "active_support/number_helper/number_to_human_size_converter"
+
+module CocinaDisplay
+  module Concerns
+    # Methods for inspecting structural metadata (e.g. file hierarchy)
+    module Structural
+      # Structured data for all individual files in the object.
+      # Traverses nested FileSet structure to return a flattened array.
+      # @return [Array<Hash>]
+      # @example
+      #  record.files.each do |file|
+      #   puts file["filename"] #=> "image1.jpg"
+      #   puts file["size"] #=> 123456
+      #  end
+      def files
+        @files ||= path("$.structural.contains.*.structural.contains.*").search
+      end
+
+      # All unique MIME types of files in this object.
+      # @return [Array<String>]
+      # @example ["image/jpeg", "application/pdf"]
+      def file_mime_types
+        files.pluck("hasMimeType").uniq
+      end
+
+      # Human-readable string representation of {total_file_size_int}.
+      # @return [String]
+      # @example "2.5 MB"
+      def total_file_size_str
+        ActiveSupport::NumberHelper.number_to_human_size(total_file_size_int)
+      end
+
+      # Summed size of all files in bytes.
+      # @return [Integer]
+      # @example 2621440
+      def total_file_size_int
+        files.pluck("size").sum
+      end
+    end
+  end
+end

--- a/spec/concerns/structural_spec.rb
+++ b/spec/concerns/structural_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../lib/cocina_display/cocina_record"
+
+RSpec.describe CocinaDisplay::CocinaRecord do
+  let(:druid) { "bb099mt5053" }
+  let(:cocina_json) { File.read(file_fixture("#{druid}.json")) }
+  let(:cocina_doc) { JSON.parse(cocina_json) }
+
+  subject { described_class.new(cocina_doc) }
+
+  describe "#files" do
+    it "returns an array of file hashes" do
+      expect(subject.files).to be_an(Array)
+      expect(subject.files.first).to be_a(Hash)
+      expect(subject.files.first["filename"]).to eq("bb099mt5053_sl.m4a")
+      expect(subject.files.first["size"]).to eq(13832365)
+    end
+  end
+
+  describe "#file_mime_types" do
+    it "returns an array of unique MIME types" do
+      expect(subject.file_mime_types).to contain_exactly("audio/mp4", "image/jp2")
+    end
+  end
+
+  describe "#total_file_size_str" do
+    it "returns a human-readable string representation of the total file size" do
+      expect(subject.total_file_size_str).to eq("14.1 MB")
+    end
+  end
+
+  describe "#total_file_size_int" do
+    it "returns the total file size in bytes" do
+      expect(subject.total_file_size_int).to eq(14744206)
+    end
+  end
+end


### PR DESCRIPTION
This adds a few methods for accessing information about an object's
files used in Dataworks.
