### PR TITLE
Add an interface for parsing related resources

### DIFF
--- a/lib/cocina_display/cocina_record.rb
+++ b/lib/cocina_display/cocina_record.rb
@@ -110,5 +110,28 @@ module CocinaDisplay
     def collection?
       content_type == "collection"
     end
+
+    # Resources related to the object.
+    # @return [Array<CocinaDisplay::RelatedResource>]
+    def related_resources
+      @related_resources ||= path("$.description.relatedResource[*]").map { |res| RelatedResource.new(res) }
+    end
+  end
+
+  # A resource related to the record; behaves like a CocinaRecord.
+  # @note Related resources have no structural metadata.
+  class RelatedResource < CocinaRecord
+    # Description of the relation to the source record.
+    # @return [String]
+    # @example "is part of"
+    # @see https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md#relatedresource-types
+    attr_reader :type
+
+    # Restructure the hash so that everything is under "description" key, since
+    # it's all descriptive metadata. This makes CocinaRecord methods work.
+    def initialize(cocina_doc)
+      @type = cocina_doc["type"]
+      @cocina_doc = {"description" => cocina_doc.except("type")}
+    end
   end
 end

--- a/spec/cocina_record_spec.rb
+++ b/spec/cocina_record_spec.rb
@@ -60,15 +60,19 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     end
   end
 
-  describe "#files" do
-    let(:druid) { "bx658jh7339" }
+  describe "#related_resources" do
+    let(:druid) { "vk217bh4910" }
 
-    it "returns the files" do
-      expect(subject.files.to_a.first).to include(
-        "filename" => "T0000001.jp2",
-        "size" => 824964,
-        "version" => 1
-      )
+    it "returns all related resources" do
+      expect(subject.related_resources.size).to eq(10)
+    end
+
+    it "knows the type of the relationship" do
+      expect(subject.related_resources.first.type).to eq "succeeded by"
+    end
+
+    it "supports calling CocinaRecord methods on the related resources" do
+      expect(subject.related_resources.first.doi).to eq "10.25740/sb4q-wj06"
     end
   end
 end


### PR DESCRIPTION
This adds a simple subclass and helper method to access the
related resources on a CocinaRecord. Because this structured data
is basically identical to the description section in a normal record,
we get access to all of the existing methods "for free" on every
related resource.

Dataworks uses this to get the identifiers (e.g. DOIs) associated with
related records, like datasets with many linked versions.
