### PR TITLE
Better handling for unencoded but compliant edtf dates

### DIFF
--- a/lib/cocina_display/dates/date_range.rb
+++ b/lib/cocina_display/dates/date_range.rb
@@ -13,7 +13,16 @@ module CocinaDisplay
       def self.from_cocina(cocina)
         return unless cocina["structuredValue"].present?
 
-        dates = cocina["structuredValue"].map { |sv| Date.from_cocina(sv) }
+        # Create the individual dates; if no encoding/type declared give them
+        # top-level encoding/type
+        dates = cocina["structuredValue"].map do |sv|
+          date = Date.from_cocina(sv)
+          date.encoding ||= cocina.dig("encoding", "code")
+          date.type ||= cocina["type"]
+          date
+        end
+
+        # Ensure we have at least a start or a stop
         start = dates.find(&:start?)
         stop = dates.find(&:end?)
         return unless start || stop

--- a/spec/dates/date_range_spec.rb
+++ b/spec/dates/date_range_spec.rb
@@ -20,6 +20,23 @@ RSpec.describe CocinaDisplay::Dates::DateRange do
     it "is also possible using the Date.from_cocina method" do
       expect(CocinaDisplay::Dates::Date.from_cocina(cocina).value).to eq(date_range.value)
     end
+
+    context "with a top-level type and no start/end types" do
+      let(:cocina) do
+        {
+          "structuredValue" => [
+            {"value" => "2023-01-01", "type" => "start"},
+            {"value" => "2023-12-31", "type" => "end"}
+          ],
+          "type" => "publication"
+        }
+      end
+
+      it "sets the type on the start and end" do
+        expect(date_range.start.type).to eq("publication")
+        expect(date_range.stop.type).to eq("publication")
+      end
+    end
   end
 
   describe "#sort_key" do
@@ -99,6 +116,11 @@ RSpec.describe CocinaDisplay::Dates::DateRange do
 
       it "returns the top-level encoding" do
         expect(date_range.encoding).to eq("edtf")
+      end
+
+      it "start and end dates also receive the encoding" do
+        expect(date_range.start.encoding).to eq("edtf")
+        expect(date_range.stop.encoding).to eq("edtf")
       end
     end
   end

--- a/spec/dates/date_spec.rb
+++ b/spec/dates/date_spec.rb
@@ -500,6 +500,22 @@ RSpec.describe CocinaDisplay::Dates::Date do
     end
   end
 
+  describe "Well-formed dates with no declared encoding" do
+    {
+      "2019-08-10" => Date.parse("2019-08-10")..Date.parse("2019-08-10"),
+      "2019-08" => Date.parse("2019-08-01")..Date.parse("2019-08-31"),
+      "2019" => Date.parse("2019-01-01")..Date.parse("2019-12-31")
+    }.each do |data, expected|
+      describe "with #{data}" do
+        let(:cocina) { {"value" => data} }
+
+        it "has the range value #{expected}" do
+          expect(date.as_range.to_s).to eq expected.to_s
+        end
+      end
+    end
+  end
+
   describe "Pulling out 4-digit years from unspecified dates" do
     {
       "Minguo 19 [1930]" => Date.parse("1930-01-01")..Date.parse("1930-12-31"),


### PR DESCRIPTION
This adds a few patterns to handle well-formed edtf dates that
did not declare edtf as their encoding, which resulted in them
using a less-accurate parser and being given only year precision.

Now, if you have an unencoded date like 2019-01-01, it is correctly
detected as full day precision.
