### PR TITLE
update to use match? instead of =~

### DIFF
--- a/lib/cocina_display/contributors/role.rb
+++ b/lib/cocina_display/contributors/role.rb
@@ -30,19 +30,19 @@ module CocinaDisplay
       # Does this role indicate the contributor is an author?
       # @return [Boolean]
       def author?
-        to_s =~ /^(author|creator|primary investigator)/i
+        to_s.match?(/^(author|creator|primary investigator)/i)
       end
 
       # Does this role indicate the contributor is a publisher?
       # @return [Boolean]
       def publisher?
-        to_s =~ /^publisher/i
+        to_s.match?(/^publisher/i)
       end
 
       # Does this role indicate the contributor is a funder?
       # @return [Boolean]
       def funder?
-        to_s =~ /^funder/i
+        to_s.match?(/^funder/i)
       end
 
       private


### PR DESCRIPTION
I found the comment of  @return [Boolean] to be confusing and not true. =~ returns the index of the match, unless there is no match. so you choices are 0 or nil which is slightly confusing when debugging. The other way works so this is just an option but I find it to be clearer.