### PR TITLE
Add Util methods to ease the process of grouping DisplayData

### DIFF
--- a/lib/cocina_display/concerns/languages.rb
+++ b/lib/cocina_display/concerns/languages.rb
@@ -17,9 +17,7 @@ module CocinaDisplay
       # Language information for display.
       # @return [Array<CocinaDisplay::DisplayData>]
       def language_display_data
-        languages.group_by(&:label).map do |label, langs|
-          CocinaDisplay::DisplayData.new(label: label, values: langs.map(&:to_s).compact_blank.uniq)
-        end.reject { |data| data.values.empty? }
+        Utils.display_data_from_objects(languages)
       end
     end
   end

--- a/lib/cocina_display/utils.rb
+++ b/lib/cocina_display/utils.rb
@@ -75,5 +75,33 @@ module CocinaDisplay
 
       output
     end
+
+    # Given objects that support #to_s and #label, group them into {DisplayData}.
+    # Groups by each object's +label+ and keeps unique, non-blank values.
+    # @param objects [Array<Object>]
+    # @return [Array<DisplayData>]
+    def self.display_data_from_objects(objects)
+      objects.group_by(&:label)
+        .map { |label, values| DisplayData.new(label: label, values: values.map(&:to_s).compact_blank.uniq) }
+        .reject { |data| data.values.empty? }
+    end
+
+    # Wrapper to make Cocina descriptive values respond to #to_s and #label.
+    DescriptiveValue = Data.define(:label, :value) do
+      def to_s
+        value
+      end
+    end
+
+    # Given an array of Cocina hashes, group them into {DisplayData}.
+    # Uses +label+ as the label if provided, but honors +displayLabel+ if set.
+    # Keeps the unique, non-blank values under each label.
+    # @param cocina [Array<Hash>]
+    # @param label [String]
+    # @return [Array<DisplayData>]
+    def self.display_data_from_cocina(cocina, label: nil)
+      objects = cocina.map { |node| DescriptiveValue.new(label: node["displayLabel"] || label, value: node["value"]) }
+      display_data_from_objects(objects)
+    end
   end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -193,4 +193,49 @@ RSpec.describe CocinaDisplay::Utils do
       end
     end
   end
+
+  describe "#display_data_from_objects" do
+    subject { described_class.display_data_from_objects(objects) }
+
+    let(:objects) do
+      [
+        {"value" => "English"},
+        {"value" => "Spanish"},
+        {"value" => ""},
+        {"code" => "eng", "source" => {"code" => "iso639-2"}},
+        {"value" => "English"},
+        {"code" => "zxx"},
+        {"code" => "egy-Egyd"},
+        {"value" => "Sumerian", "displayLabel" => "Primary language"}
+      ].map { |lang| CocinaDisplay::Language.new(lang) }
+    end
+
+    it "groups objects by label and keeps unique, non-blank values" do
+      is_expected.to contain_exactly(
+        be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Language", values: ["English", "Spanish", "Egyptian, Demotic"])),
+        be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Primary language", values: ["Sumerian"]))
+      )
+    end
+  end
+
+  describe "#display_data_from_cocina" do
+    subject { described_class.display_data_from_cocina(cocina, label: "Language") }
+
+    let(:cocina) do
+      [
+        {"value" => "English"},
+        {"value" => "Spanish"},
+        {"value" => ""},
+        {"value" => "English"},
+        {"value" => "Sumerian", "displayLabel" => "Primary language"}
+      ]
+    end
+
+    it "groups objects by label and keeps unique, non-blank values" do
+      is_expected.to contain_exactly(
+        be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Language", values: ["English", "Spanish"])),
+        be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Primary language", values: ["Sumerian"]))
+      )
+    end
+  end
 end


### PR DESCRIPTION
This adds two generic utility methods for grouping values together
under labels/headings as DisplayData.

One is designed for grouping objects that wrap data, which already
respond to #label and #to_s.

The other applies the same process to hashes parsed from Cocina
JSON, which don't respond to these methods, using a wrapper.
