### PR TITLE
Separate resource type display from forms

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
         genre: "Genre"
         map_projection: "Map data"
         map_scale: "Map data"
+        resource_type: "Type of resource"
       identifier:
         doi: DOI
         handle: Handle
@@ -54,4 +55,3 @@ en:
         subject: Subject
         topic: Subject
       use_and_reproduction: Use and reproduction statement
-

--- a/lib/cocina_display/forms/form.rb
+++ b/lib/cocina_display/forms/form.rb
@@ -8,16 +8,30 @@ module CocinaDisplay
       attr_reader :cocina
 
       # Create a Form object from Cocina structured data.
+      # Delegates to subclasses for specific types.
+      # @param cocina [Hash]
+      # @return [Form]
+      def self.from_cocina(cocina)
+        case cocina["type"]
+        when "genre"
+          Genre.new(cocina)
+        when "resource type"
+          ResourceType.new(cocina)
+        else
+          new(cocina)
+        end
+      end
+
+      # Create a Form object from Cocina structured data.
       # @param cocina [Hash]
       def initialize(cocina)
         @cocina = cocina
       end
 
       # The value to use for display.
-      # Genre values are capitalized; other form values are not.
       # @return [String]
       def to_s
-        (type == "genre") ? flat_value&.upcase_first : flat_value
+        flat_value
       end
 
       # Single concatenated string value for the form.

--- a/lib/cocina_display/forms/genre.rb
+++ b/lib/cocina_display/forms/genre.rb
@@ -1,0 +1,12 @@
+module CocinaDisplay
+  module Forms
+    # A Genre form associated with part or all of a Cocina object.
+    class Genre < Form
+      # Genres are capitalized for display.
+      # @return [String]
+      def to_s
+        super&.upcase_first
+      end
+    end
+  end
+end

--- a/lib/cocina_display/forms/resource_type.rb
+++ b/lib/cocina_display/forms/resource_type.rb
@@ -1,0 +1,27 @@
+module CocinaDisplay
+  module Forms
+    # A Resource Type form associated with part or all of a Cocina object.
+    class ResourceType < Form
+      # Resource types are lowercased for display.
+      # @return [String]
+      def to_s
+        super&.downcase
+      end
+
+      # Is this a Stanford self-deposit resource type?
+      # @note These are handled separately when displayed.
+      # @return [Boolean]
+      def stanford_self_deposit?
+        cocina.dig("source", "value") == "Stanford self-deposit resource types"
+      end
+
+      private
+
+      # Stanford self-deposit resource types are labeled "Genre".
+      # @return [String]
+      def type_label
+        (I18n.t("cocina_display.field_label.form.genre") if stanford_self_deposit?) || super
+      end
+    end
+  end
+end

--- a/spec/concerns/forms_spec.rb
+++ b/spec/concerns/forms_spec.rb
@@ -244,5 +244,49 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         ))
       )
     end
+
+    context "with multiple kinds of resource type" do
+      let(:forms) do
+        [
+          {
+            "structuredValue" => [
+              {"value" => "Text", "type" => "type"},
+              {"value" => "Policy brief", "type" => "subtype"}
+            ],
+            "type" => "resource type",
+            "source" => {
+              "value" => "Stanford self-deposit resource types"
+            }
+          },
+          {
+            "value" => "text",
+            "type" => "resource type",
+            "source" => {"value" => "MODS resource types"}
+          },
+          {
+            "value" => "Text",
+            "type" => "resource type",
+            "source" => {"value" => "DataCite resource types"}
+          },
+          {
+            "value" => "Something else",
+            "type" => "form"
+          }
+        ]
+      end
+
+      it "deduplicates and formats the resource types separately, excluding self-deposit" do
+        is_expected.to contain_exactly(
+          be_a(CocinaDisplay::DisplayData).and(have_attributes(
+            label: "Type of resource",
+            values: ["text"]
+          )),
+          be_a(CocinaDisplay::DisplayData).and(have_attributes(
+            label: "Form",
+            values: ["Something else"]
+          ))
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes #76 by implementing special handling for resource types:

- Resource types have their own display label ("Type of resource")
and are separate from other form data
- ...except for stanford self-deposit resources types, which are
grouped with Genres (and can be structured)

This behavior is visible on zs631wn7371 and zw438wf4318 (staging).
