### PR TITLE
Handle URLs separately from display data

### DIFF
--- a/lib/cocina_display/concerns/accesses.rb
+++ b/lib/cocina_display/concerns/accesses.rb
@@ -2,13 +2,12 @@ module CocinaDisplay
   module Concerns
     # Methods for extracting access/location information from a Cocina object.
     module Accesses
-      # Display data for all access metadata except contact emails
+      # Display data for all access metadata except contact emails and URLs
       # @return [Array<DisplayData>]
       def access_display_data
         CocinaDisplay::DisplayData.from_objects(accesses +
                                                 access_contacts.reject(&:contact_email?) +
-                                                purls +
-                                                urls)
+                                                purls)
       end
 
       # Display data for all access contact email metadata

--- a/lib/cocina_display/display_data.rb
+++ b/lib/cocina_display/display_data.rb
@@ -72,53 +72,19 @@ module CocinaDisplay
 
     attr_reader :label
 
-    # A Data object to hold link text and URL for link metadata.
-    # @attr [String] link_text
-    # @attr [String] url
-    LinkData = Data.define(:link_text, :url)
-
     # The unique, non-blank values for display
-    # @return [Array<String, LinkData>]
+    # @return [Array<String>]
     def values
-      values_for_display.compact_blank.uniq
+      @objects.flat_map { |obj| split_string_on_newlines(obj.to_s) }.compact_blank.uniq
     end
 
     private
-
-    # Extract the values for display from the objects.
-    # @return [Array<String, LinkData>]
-    def values_for_display
-      @objects.flat_map do |object|
-        if object.respond_to?(:link_text) || url?(object.to_s)
-          convert_url_strings_to_link_data(object)
-        else
-          split_string_on_newlines(object.to_s)
-        end
-      end
-    end
-
-    # Convert a URL string or object with link text to a LinkData object.
-    # @param object [Object] The object to convert
-    # @return [LinkData]
-    def convert_url_strings_to_link_data(object)
-      LinkData.new(link_text: (object.respond_to?(:link_text) ? object.link_text : nil), url: object.to_s)
-    end
 
     # Split a string on newlines (including HTML-encoded newlines) and strip whitespace.
     # @param string [String] The string to split
     # @return [Array<String>]
     def split_string_on_newlines(string)
       string&.gsub("&#10;", "\n")&.split("\n")&.map(&:strip)
-    end
-
-    # Whether a string looks like a URL.
-    # @param string [String] The string to check
-    # @return [Boolean]
-    def url?(string)
-      uri = URI.parse(string)
-      uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-    rescue URI::InvalidURIError
-      false
     end
   end
 end

--- a/spec/concerns/accesses_spec.rb
+++ b/spec/concerns/accesses_spec.rb
@@ -22,10 +22,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     it "returns an array of access display data" do
       expect(record.access_display_data).to contain_exactly(
         be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Special location", values: ["Series: The Prosecutor v. Sabino Gouveia Leite"])),
-        be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Location", values: contain_exactly(
-          be_a(CocinaDisplay::DisplayData::LinkData).and(have_attributes(link_text: nil, url: "https://purl.stanford.edu/km388vz4371")),
-          be_a(CocinaDisplay::DisplayData::LinkData).and(have_attributes(link_text: "My favorite website", url: "https://example.com"))
-        )))
+        be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Location", values: ["https://purl.stanford.edu/km388vz4371"]))
       )
     end
   end

--- a/spec/concerns/identifiers_spec.rb
+++ b/spec/concerns/identifiers_spec.rb
@@ -250,10 +250,8 @@ RSpec.describe CocinaDisplay::CocinaRecord do
 
     it "returns an array of DisplayValue objects" do
       expect(subject.identifier_display_data).to contain_exactly(
-        be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "DOI", values: contain_exactly(
-          be_a(CocinaDisplay::DisplayData::LinkData).and(have_attributes(link_text: nil, url: "https://doi.org/10.25740/ppax-bf07")),
-          be_a(CocinaDisplay::DisplayData::LinkData).and(have_attributes(link_text: nil, url: "https://doi.org/10.25740/sb4q-wj06"))
-        ))),
+        be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "DOI", values: ["https://doi.org/10.25740/ppax-bf07",
+          "https://doi.org/10.25740/sb4q-wj06"])),
         be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "ISBN", values: ["978-0-061-96436-7"])),
         be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Identifier", values: ["other-id-123", "other-id-456"])),
         be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Custom label", values: ["custom-id-123"]))

--- a/spec/display_data_spec.rb
+++ b/spec/display_data_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe CocinaDisplay::DisplayData do
 
     it "returns the values from the objects" do
       is_expected.to contain_exactly("A real note",
-        be_a(CocinaDisplay::DisplayData::LinkData).and(have_attributes(link_text: nil, url: "https://example.com")),
+        "https://example.com",
         "A note with a URL in the middle of the text https://example.com and more text")
     end
 


### PR DESCRIPTION
@thatbudakguy I'm thinking about handling URLs with link text, Contributors with Orcids, and Related resources with nested labels/values as special cases that we could handle outside DisplayData. With this approach DisplayData values are predictable and always strings for consumers. And more complex cases are handled via their own methods and logic.