### PR TITLE
Don't attempt to decode language codes that aren't in Searchworks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       edtf (~> 3.2)
       geo_coord (~> 0.2)
       i18n
-      iso639 (~> 1.3)
       janeway-jsonpath (~> 0.6)
       zeitwerk (~> 2.7)
 
@@ -56,7 +55,6 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    iso639 (1.3.3)
     janeway-jsonpath (0.6.0)
     json (2.13.2)
     language_server-protocol (3.17.0.5)

--- a/cocina_display.gemspec
+++ b/cocina_display.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 7" # for helpers like present?
   spec.add_dependency "edtf", "~> 3.2" # for parsing dates
   spec.add_dependency "i18n" # for translations of display labels
-  spec.add_dependency "iso639", "~> 1.3" # for parsing language codes
   spec.add_dependency "geo_coord", "~> 0.2" # for parsing coordinates
   spec.add_dependency "zeitwerk", "~> 2.7" # autoloading
 

--- a/lib/cocina_display.rb
+++ b/lib/cocina_display.rb
@@ -10,7 +10,6 @@ require "active_support/core_ext/object/blank"
 require "active_support/core_ext/hash/conversions"
 require "geo/coord"
 require "edtf"
-require "iso639"
 require "i18n"
 require "i18n/backend/fallbacks"
 I18n::Backend::Simple.include I18n::Backend::Fallbacks

--- a/lib/cocina_display/language.rb
+++ b/lib/cocina_display/language.rb
@@ -26,7 +26,7 @@ module CocinaDisplay
     # Decoded name of the language based on the code, if present.
     # @return [String, nil]
     def decoded_value
-      Vocabularies::SEARCHWORKS_LANGUAGES[code] || (Iso639[code] if iso_639?)
+      Vocabularies::SEARCHWORKS_LANGUAGES[code] if searchworks_language?
     end
 
     # Display label for this field.
@@ -39,14 +39,7 @@ module CocinaDisplay
     # @see CocinaDisplay::Vocabularies::SEARCHWORKS_LANGUAGES
     # @return [Boolean]
     def searchworks_language?
-      Vocabularies::SEARCHWORKS_LANGUAGES.value?(to_s)
-    end
-
-    # True if the language has a code sourced from the ISO 639 vocabulary.
-    # @see https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
-    # @return [Boolean]
-    def iso_639?
-      cocina.dig("source", "code")&.start_with? "iso639"
+      Vocabularies::SEARCHWORKS_LANGUAGES.value?(cocina["value"]) || Vocabularies::SEARCHWORKS_LANGUAGES.key?(code)
     end
   end
 end

--- a/spec/concerns/languages_spec.rb
+++ b/spec/concerns/languages_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
           {"value" => ""},
           {"code" => "eng", "source" => {"code" => "iso639-2"}},
           {"value" => "English"},
-          {"code" => "zxx"},
+          {"code" => "zxx", "source" => {"code" => "iso639-2b"}},
           {"code" => "egy-Egyd"},
           {"value" => "Sumerian", "displayLabel" => "Primary language"}
         ]


### PR DESCRIPTION
Also removes the dependency on iso639 gem since we have a complete
code to name mapping for Searchworks.

This fixes #165 because non-Searchworks lanugage codes mapping to
Iso639::Language instances is the source of that bug.
