### PR TITLE
Handle precoordinated subject headings

### DIFF
--- a/lib/cocina_display/contributors/name.rb
+++ b/lib/cocina_display/contributors/name.rb
@@ -25,10 +25,6 @@ module CocinaDisplay
       end
 
       # The display string for the name, optionally including life dates.
-      # Uses these values in order, if present:
-      # 1. Unstructured value
-      # 2. Any structured/parallel values marked as "display"
-      # 3. Joined structured values, optionally with life dates
       # @param with_date [Boolean] Include life dates, if present
       # @return [String]
       # @example no dates
@@ -38,8 +34,6 @@ module CocinaDisplay
       def to_s(with_date: false)
         if cocina["value"].present?
           cocina["value"]
-        elsif display_name_str.present?
-          display_name_str
         elsif dates_str.present? && with_date
           Utils.compact_and_join([full_name_str, dates_str], delimiter: ", ")
         else
@@ -51,12 +45,6 @@ module CocinaDisplay
       # @return [String]
       def full_name_str
         Utils.compact_and_join(name_components.push(terms_of_address_str), delimiter: ", ")
-      end
-
-      # Flattened form of any names explicitly marked as "display name".
-      # @return [String]
-      def display_name_str
-        Utils.compact_and_join(Array(name_values["display"]), delimiter: ", ")
       end
 
       # List of all name components.

--- a/lib/cocina_display/subjects/subject.rb
+++ b/lib/cocina_display/subjects/subject.rb
@@ -51,9 +51,9 @@ module CocinaDisplay
       def subject_values
         @subject_values ||= (Array(cocina["parallelValue"]).presence || [cocina]).flat_map do |node|
           if SubjectValue.atomic_types.include?(type)
-            [SubjectValue.from_cocina(node, type: type)]
+            SubjectValue.from_cocina(node, type: type)
           else
-            Utils.flatten_nested_values(node, atomic_types: SubjectValue.atomic_types).map do |value|
+            Utils.flatten_nested_values(node, atomic_types: SubjectValue.atomic_types).flat_map do |value|
               SubjectValue.from_cocina(value, type: value["type"] || type)
             end
           end

--- a/lib/cocina_display/subjects/subject_value.rb
+++ b/lib/cocina_display/subjects/subject_value.rb
@@ -10,9 +10,12 @@ module CocinaDisplay
 
       # Create a SubjectValue from Cocina structured data.
       # @param cocina [Hash] The Cocina structured data for the subject.
+      # @param type [String, nil] The type, coming from the parent Subject.
       # @return [SubjectValue]
-      def self.from_cocina(cocina)
-        SUBJECT_VALUE_TYPES.fetch(cocina["type"], SubjectValue).new(cocina)
+      def self.from_cocina(cocina, type:)
+        SUBJECT_VALUE_TYPES.fetch(type, SubjectValue).new(cocina).tap do |obj|
+          obj.type ||= type
+        end
       end
 
       # All subject value types that should not be further destructured.

--- a/lib/cocina_display/subjects/subject_value.rb
+++ b/lib/cocina_display/subjects/subject_value.rb
@@ -8,13 +8,28 @@ module CocinaDisplay
       # @see https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md#subject-part-types-for-structured-value
       attr_accessor :type
 
-      # Create a SubjectValue from Cocina structured data.
+      # Create SubjectValues from Cocina structured data.
+      # Pre-coordinated string values will be split into multiple SubjectValues.
       # @param cocina [Hash] The Cocina structured data for the subject.
       # @param type [String, nil] The type, coming from the parent Subject.
-      # @return [SubjectValue]
+      # @return [Array<SubjectValue>]
       def self.from_cocina(cocina, type:)
-        SUBJECT_VALUE_TYPES.fetch(type, SubjectValue).new(cocina).tap do |obj|
-          obj.type ||= type
+        split_pre_coordinated_values(cocina, type: type).map do |value|
+          SUBJECT_VALUE_TYPES.fetch(type, SubjectValue).new(value).tap do |obj|
+            obj.type ||= type
+          end
+        end
+      end
+
+      # Split a pre-coordinated subject value joined with "--" into multiple values.
+      # Ignores the "--" string for coordinate subject types, which use it differently.
+      # @param cocina [Hash] The Cocina structured data for the subject.
+      # @return [Array<Hash>] An array of Cocina hashes, one for each split value
+      def self.split_pre_coordinated_values(cocina, type:)
+        if cocina["value"].is_a?(String) && cocina["value"].include?("--") && !type.include?("coordinates")
+          cocina["value"].split("--").map { |v| cocina.merge("value" => v.strip) }
+        else
+          [cocina]
         end
       end
 

--- a/lib/cocina_display/utils.rb
+++ b/lib/cocina_display/utils.rb
@@ -21,7 +21,7 @@ module CocinaDisplay
       end.delete_suffix(delimiter)
     end
 
-    # Recursively flatten structured, parallel, and grouped values in Cocina metadata.
+    # Recursively flatten structured, and grouped values in Cocina metadata.
     # Returns a list of hashes representing the "leaf" nodes with +value+ key.
     # @return [Array<Hash>] List of node hashes with "value" present
     # @param cocina [Hash] The Cocina structured data to flatten
@@ -35,8 +35,8 @@ module CocinaDisplay
     #  cocina = { "structuredValue" => [{"value" => "foo"},  {"value" => "bar"}] }
     #  Utils.flatten_nested_values(cocina)
     #  #=> [{"value" => "foo"}, {"value" => "bar"}]
-    # @example parallel structured and simple values
-    #  cocina = { "parallelValue" => [{"value" => "foo" }, { "structuredValue" => [{"value" => "bar"},  {"value" => "baz"}] }] }
+    # @example nested structured and simple values
+    #  cocina = { "structuredValue" => [{"value" => "foo" }, { "structuredValue" => [{"value" => "bar"},  {"value" => "baz"}] }] }
     #  Utils.flatten_nested_values(cocina)
     #  #=> [{"value" => "foo"}, {"value" => "foo"}, {"value" => "baz"}]
     def self.flatten_nested_values(cocina, output = [], atomic_types: [])
@@ -44,7 +44,7 @@ module CocinaDisplay
       return [cocina] if atomic_types.include?(cocina["type"])
       return cocina.flat_map { |node| flatten_nested_values(node, output, atomic_types: atomic_types) } if cocina.is_a?(Array)
 
-      nested_values = Array(cocina["structuredValue"]) + Array(cocina["parallelValue"]) + Array(cocina["groupedValue"])
+      nested_values = Array(cocina["structuredValue"]) + Array(cocina["groupedValue"])
       return output unless nested_values.any?
 
       nested_values.flat_map { |node| flatten_nested_values(node, output, atomic_types: atomic_types) }

--- a/spec/concerns/subjects_spec.rb
+++ b/spec/concerns/subjects_spec.rb
@@ -90,6 +90,23 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         is_expected.to eq(["Emprisonnement"])
       end
     end
+
+    context "with pre-coordinated LCSH topic subjects" do
+      let(:subjects) do
+        [
+          {
+            "type" => "topic",
+            "value" => "Presidents--Election",
+            "uri" => "http://id.loc.gov/authorities/subjects/sh85106460",
+            "source" => {"code" => "lcsh", "uri" => "http://id.loc.gov/authorities/subjects/"}
+          }
+        ]
+      end
+
+      it "splits the value on --" do
+        is_expected.to eq(["Presidents", "Election"])
+      end
+    end
   end
 
   describe "#subject_names" do
@@ -463,6 +480,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
             {"value" => "Italy", "type" => "topic"}
           ]
         },
+        {"type" => "topic", "value" => "Presidents--Election"}, # pre-coordinated; replace '--' with ' > '
         {"type" => "genre", "value" => "Science Fiction"},  # ignored; goes in genre
         {"type" => "topic", "value" => "History"},
         {"type" => "map coordinates", "value" => "W 18°--E 51°/N 37°--S 35°"}, # ignored; goes in map data
@@ -476,6 +494,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
           label: "Subject",
           values: [
             "Painters > Italy",
+            "Presidents > Election",
             "History"
           ]
         ))

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -41,51 +41,6 @@ RSpec.describe CocinaDisplay::Utils do
       end
     end
 
-    context "with parallel values" do
-      let(:cocina) do
-        {
-          "parallelValue" => [
-            {"value" => "John Doe", "type" => "name"},
-            {"value" => "Jane Smith", "type" => "name"}
-          ]
-        }
-      end
-
-      it "flattens parallel values into a single array" do
-        is_expected.to eq([
-          {"value" => "John Doe", "type" => "name"},
-          {"value" => "Jane Smith", "type" => "name"}
-        ])
-      end
-    end
-
-    context "with mixed structured and parallel values" do
-      let(:cocina) do
-        {
-          "parallelValue" => [
-            {
-              "value" => "John Doe",
-              "type" => "name"
-            },
-            {
-              "structuredValue" => [
-                {"value" => "King", "type" => "term of address"},
-                {"value" => "1920 - 2000", "type" => "life dates"}
-              ]
-            }
-          ]
-        }
-      end
-
-      it "flattens all nodes into a single array" do
-        is_expected.to eq([
-          {"value" => "John Doe", "type" => "name"},
-          {"value" => "King", "type" => "term of address"},
-          {"value" => "1920 - 2000", "type" => "life dates"}
-        ])
-      end
-    end
-
     context "with grouped values" do
       let(:cocina) do
         # from druid:sw705fr7011


### PR DESCRIPTION
- **Don't flatten parallelValues when flattening**
- **Handle parallel subject values**
- **Destructure precoordinated subject headings**
- **Remove unused code for handling parallel names**

This fixes #153 for both indexing-related and display-related use cases.