### PR TITLE
Generalize DisplayData#from_string helper to accept multiple

### DIFF
--- a/lib/cocina_display/concerns/accesses.rb
+++ b/lib/cocina_display/concerns/accesses.rb
@@ -21,7 +21,7 @@ module CocinaDisplay
       # Exhibits and EarthWorks handle useAndReproductionStatement like descriptive metadata.
       # @return [Array<CocinaDisplay::DisplayData>]
       def use_and_reproduction_display_data
-        CocinaDisplay::DisplayData.from_string(use_and_reproduction,
+        CocinaDisplay::DisplayData.from_strings([use_and_reproduction],
           label: I18n.t("cocina_display.field_label.use_and_reproduction"))
       end
 
@@ -29,12 +29,12 @@ module CocinaDisplay
       # Exhibits and EarthWorks handle copyright like descriptive metadata.
       # @return [Array<CocinaDisplay::DisplayData>]
       def copyright_display_data
-        CocinaDisplay::DisplayData.from_string(copyright,
+        CocinaDisplay::DisplayData.from_strings([copyright],
           label: I18n.t("cocina_display.field_label.copyright"))
       end
 
       def license_display_data
-        CocinaDisplay::DisplayData.from_string(license_description,
+        CocinaDisplay::DisplayData.from_strings([license_description],
           label: I18n.t("cocina_display.field_label.license"))
       end
 
@@ -71,7 +71,7 @@ module CocinaDisplay
       def purls
         return [] unless purl_url.present?
 
-        CocinaDisplay::DisplayData.descriptive_values_from_string(purl_url, label: I18n.t("cocina_display.field_label.purl"))
+        CocinaDisplay::DisplayData.descriptive_values_from_strings([purl_url], label: I18n.t("cocina_display.field_label.purl"))
       end
     end
   end

--- a/lib/cocina_display/display_data.rb
+++ b/lib/cocina_display/display_data.rb
@@ -24,21 +24,21 @@ module CocinaDisplay
         from_objects(descriptive_values_from_cocina(cocina, label: label))
       end
 
-      # Create display data from a string value.
-      # @param value [String] The string value to display
+      # Create display data from string values.
+      # @param value [String] The string values to display
       # @param label [String] The label for the display data
       # @return [Array<DisplayData>] The display data
-      def from_string(value, label: nil)
-        from_objects(descriptive_values_from_string(value, label: label))
+      def from_strings(values, label: nil)
+        from_objects(descriptive_values_from_strings(values, label: label))
       end
 
-      # Create an array containing a descriptive object from a string value.
+      # Create an array containing a descriptive object from string values.
       # Can be used to combine a string derived value with other metadata objects.
-      # @param string [String] The string value to display
+      # @param strings [Array<String>] The string values to display
       # @param label [String] The label for the display data
       # @return [Array<DescriptiveValue>] The descriptive values
-      def descriptive_values_from_string(string, label: nil)
-        [DescriptiveValue.new(label: label, value: string)]
+      def descriptive_values_from_strings(strings, label: nil)
+        strings.map { |string| DescriptiveValue.new(label: label, value: string) }
       end
 
       # Take one or several DisplayData and merge into a single hash.
@@ -72,7 +72,7 @@ module CocinaDisplay
 
     # Create a DisplayData object from a list of objects that share a label
     # @param label [String]
-    # @param objects [Array<Object>]
+    # @param objects [Array<#to_s>]
     def initialize(label:, objects:)
       @label = label
       @objects = objects

--- a/spec/display_data_spec.rb
+++ b/spec/display_data_spec.rb
@@ -46,27 +46,28 @@ RSpec.describe CocinaDisplay::DisplayData do
     end
   end
 
-  describe ".from_string" do
-    subject { described_class.from_string(value, label: label) }
-    let(:value) { "Some text" }
+  describe ".from_strings" do
+    subject { described_class.from_strings(values, label: label) }
+    let(:values) { ["Some text", "Another text"] }
     let(:label) { "Some label" }
 
     it "returns an array containing a DisplayData object" do
       is_expected.to contain_exactly(
-        be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Some label", values: ["Some text"]))
+        be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Some label", values: ["Some text", "Another text"]))
       )
     end
   end
 
-  describe ".descriptive_values_from_string" do
-    subject { described_class.descriptive_values_from_string(string, label: label) }
-    let(:string) { "Some text" }
+  describe ".descriptive_values_from_strings" do
+    subject { described_class.descriptive_values_from_strings(strings, label: label) }
+    let(:strings) { ["Some text", "Another text"] }
     let(:label) { "Some label" }
 
     it "returns an array containing an object with label and value attributes" do
       is_expected.to contain_exactly(
-       have_attributes(label: "Some label", value: "Some text")
-     )
+        have_attributes(label: "Some label", value: "Some text"),
+        have_attributes(label: "Some label", value: "Another text")
+      )
     end
   end
 


### PR DESCRIPTION
This allows better support for some behavior in PURL, where we
are creating custom DisplayData using the values output by other
methods that return arrays of strings.
