### PR TITLE
allow for subjects without type

### DIFF
--- a/lib/cocina_display/subjects/subject_value.rb
+++ b/lib/cocina_display/subjects/subject_value.rb
@@ -26,7 +26,7 @@ module CocinaDisplay
       # @param cocina [Hash] The Cocina structured data for the subject.
       # @return [Array<Hash>] An array of Cocina hashes, one for each split value
       def self.split_pre_coordinated_values(cocina, type:)
-        if cocina["value"].is_a?(String) && cocina["value"].include?("--") && !type.include?("coordinates")
+        if cocina["value"].is_a?(String) && cocina["value"].include?("--") && !type&.include?("coordinates")
           cocina["value"].split("--").map { |v| cocina.merge("value" => v.strip) }
         else
           [cocina]

--- a/spec/concerns/subjects_spec.rb
+++ b/spec/concerns/subjects_spec.rb
@@ -463,6 +463,21 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       end
     end
 
+    context "with pre-coordinated LCSH topic subjects and no type" do
+      let(:subjects) do
+        [
+          {
+            "value" => "Presidents--Election",
+            "uri" => "http://id.loc.gov/authorities/subjects/sh85106460"
+          }
+        ]
+      end
+
+      it "splits the value on --" do
+        is_expected.to eq(["Presidents > Election"])
+      end
+    end
+
     context "with deeply nested structured subjects of different types" do
       # from druid:kj040zn0537
       let(:subjects) do


### PR DESCRIPTION
closes https://github.com/sul-dlss/purl/issues/1628

Here is an example record https://purl.stanford.edu/fj561mx1945.json that has a subject without a type (see Lobsters--Behavior) that needs to split