### PR TITLE
Ensure related resources with only a DOI get DisplayData

### DIFF
--- a/lib/cocina_display/related_resource.rb
+++ b/lib/cocina_display/related_resource.rb
@@ -38,14 +38,14 @@ module CocinaDisplay
     # String representation of the related resource.
     # @return [String, nil]
     def to_s
-      main_title || url
+      display_data.flat_map(&:values).first
     end
 
     # URL to the related resource for link construction.
     # If there are multiple URLs, uses the first.
     # @return [String, nil]
     def url
-      urls.first&.to_s || purl_url
+      (urls.map(&:to_s) + identifiers.map(&:uri) + [purl_url]).compact.first
     end
 
     # Is this a related resource with a URL?
@@ -59,7 +59,7 @@ module CocinaDisplay
     # @note Used for extended display of citations, e.g. on hp566jq8781.
     # @return [Array<DisplayData>]
     def display_data
-      title_display_data + contributor_display_data + general_note_display_data + preferred_citation_display_data + access_display_data
+      title_display_data + contributor_display_data + general_note_display_data + preferred_citation_display_data + access_display_data + identifier_display_data
     end
 
     private

--- a/spec/concerns/related_resources_spec.rb
+++ b/spec/concerns/related_resources_spec.rb
@@ -33,16 +33,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
   end
 
   describe "#related_resource_display_data" do
-    # Create nested hash structure from display data for easier testing
-    subject do
-      record.related_resource_display_data.map do |dd|
-        {
-          dd.label => dd.objects.flat_map(&:display_data).flat_map do |dd2|
-            {dd2.label => dd2.values}
-          end
-        }
-      end.reduce(:merge)
-    end
+    subject { CocinaDisplay::DisplayData.to_hash(record.related_resource_display_data) }
 
     # taken from druid:hp566jq8781
     context "with relations that include display labels" do
@@ -64,12 +55,8 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       it "uses the display labels" do
         is_expected.to eq(
           {
-            "Downloadable James Catalogue Record" => [
-              {"Title" => ["https://stacks.stanford.edu/file/druid:vz744tc9861/MS_367.pdf"]}
-            ],
-            "Superseded Interim Catalogue Record" => [
-              {"Title" => ["https://stacks.stanford.edu/file/druid:pw577ky6421/367.pdf"]}
-            ]
+            "Downloadable James Catalogue Record" => ["https://stacks.stanford.edu/file/druid:vz744tc9861/MS_367.pdf"],
+            "Superseded Interim Catalogue Record" => ["https://stacks.stanford.edu/file/druid:pw577ky6421/367.pdf"]
           }
         )
       end
@@ -128,13 +115,45 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         is_expected.to eq(
           {
             "Referenced by" => [
-              {"Title" => ["Wardington, Lord: The Book Collector, 2003. vol. 52 pgs 199-211 & 317-355"]},
-              {"Title" => ["Phillips. 203"]},
-              {"Title" => ["Tooley. 395"]}
+              "Wardington, Lord: The Book Collector, 2003. vol. 52 pgs 199-211 & 317-355",
+              "Phillips. 203",
+              "Tooley. 395"
             ],
-            "Related item" => [
-              {"Location" => ["https://purl.stanford.edu/wj967bm6421"]}
+            "Related item" => ["https://purl.stanford.edu/wj967bm6421"]
+          }
+        )
+      end
+    end
+
+    context "with related resources with DOIs" do
+      let(:related_resources) do
+        [
+          {
+            "type" => "succeeded by",
+            "identifier" => [
+              {
+                "value" => "10.25740/sb4q-wj06",
+                "type" => "doi"
+              }
             ]
+          },
+          {
+            "type" => "supplement to",
+            "identifier" => [
+              {
+                "value" => "10.1234/abcde",
+                "type" => "doi"
+              }
+            ]
+          }
+        ]
+      end
+
+      it "returns display data with the DOIs" do
+        is_expected.to eq(
+          {
+            "Succeeded by" => ["https://doi.org/10.25740/sb4q-wj06"],
+            "Supplement to" => ["https://doi.org/10.1234/abcde"]
           }
         )
       end


### PR DESCRIPTION
There were some cases testable using staging purl kb478bv3993
where items had only a DOI and a relationship type, but no title
or other information.

This ensures that we still pick up the DOI as both the title for
rendering and the URL that should be linked to.
