### PR TITLE
Support querying and formatting Contributor affiliations

### DIFF
--- a/lib/cocina_display/contributors/affiliation.rb
+++ b/lib/cocina_display/contributors/affiliation.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module CocinaDisplay
+  module Contributors
+    # An affiliation associated with a contributor.
+    class Affiliation
+      attr_reader :cocina
+
+      # Initialize an Affiliation from Cocina structured data.
+      # @param cocina [Hash]
+      def initialize(cocina)
+        @cocina = cocina
+      end
+
+      # String representation of the affiliation, using display name.
+      # @return [String, nil]
+      def to_s
+        display_name
+      end
+
+      # The name of the institution or organization.
+      # @return [String, nil]
+      # @example "Stanford University, Department of Special Collections"
+      def display_name
+        name_components.join(", ") if name_components.any?
+      end
+
+      # Does this Affiliation have a ROR ID?
+      # @return [Boolean]
+      def ror?
+        ror_identifier.present?
+      end
+
+      # ROR URI for the Affiliation, if present.
+      # @return [String, nil]
+      # @example https://ror.org/00f54p054
+      def ror
+        ror_identifier&.uri
+      end
+
+      # ROR ID for the Affiliation, if present.
+      # @return [String, nil]
+      # @example 00f54p054
+      def ror_id
+        ror_identifier&.identifier
+      end
+
+      # Identifiers associated with the Affiliation.
+      # @return [Array<CocinaDisplay::Identifier>]
+      def identifiers
+        @identifiers ||= Utils.flatten_nested_values(cocina)
+          .pluck("identifier").flatten.compact_blank.map { |id| CocinaDisplay::Identifier.new(id) }
+      end
+
+      # All components of the Affiliation name as an array of strings.
+      # @return [Array<String>]
+      # @example ["Stanford University", "Department of Special Collections"]
+      def name_components
+        @name_components ||= Utils.flatten_nested_values(cocina).pluck("value").compact_blank
+      end
+
+      # The first Identifier object that contains a ROR ID.
+      # @note This will usually be the most general ROR ID, if multiple.
+      # @return [CocinaDisplay::Identifier, nil]
+      def ror_identifier
+        identifiers.find { |id| id.type == "ROR" }
+      end
+    end
+  end
+end

--- a/lib/cocina_display/contributors/contributor.rb
+++ b/lib/cocina_display/contributors/contributor.rb
@@ -24,12 +24,6 @@ module CocinaDisplay
         other.is_a?(Contributor) && other.cocina == cocina
       end
 
-      # Identifiers for the contributor.
-      # @return [Array<Identifier>]
-      def identifiers
-        Array(cocina["identifier"]).map { |id| Identifier.new(id) }
-      end
-
       # Is this contributor a human?
       # @return [Boolean]
       def person?
@@ -135,6 +129,46 @@ module CocinaDisplay
       # @return [Array<Hash>]
       def roles
         @roles ||= Array(cocina["role"]).map { |role| Role.new(role) }
+      end
+
+      # Affiliation data for the contributor.
+      # @return [Array<CocinaDisplay::Contributors::Affiliation>]
+      def affiliations
+        @affiliations ||= Array(cocina["affiliation"]).map { |affiliation| Affiliation.new(affiliation) }
+      end
+
+      # Identifiers for the contributor.
+      # @return [Array<Identifier>]
+      def identifiers
+        @identifiers ||= Array(cocina["identifier"]).map { |id| Identifier.new(id) }
+      end
+
+      # Does this contributor have an ORCID?
+      # @return [Boolean]
+      def orcid?
+        orcid_identifier.present?
+      end
+
+      # ORCID URI for the contributor, if present.
+      # @return [String, nil]
+      # @example https://orcid.org/0000-0003-4168-7198
+      def orcid
+        orcid_identifier&.uri
+      end
+
+      # ORCID ID for the contributor, if present.
+      # @return [String, nil]
+      # @example 0000-0003-4168-7198
+      def orcid_id
+        orcid_identifier&.identifier
+      end
+
+      private
+
+      # The first Identifier object containing an ORCID.
+      # @return [CocinaDisplay::Identifier, nil]
+      def orcid_identifier
+        identifiers.find { |id| id.type == "ORCID" }
       end
     end
   end


### PR DESCRIPTION
This adds some support for features needed in Dataworks to
retrieve and format contributor affiliations (which may be structured)
in addition to ROR IDs for those affiliations and ORCIDs for the
contributors.

Closes #202
