### PR TITLE
Make some contributor role methods public

### DIFF
--- a/lib/cocina_display/contributors/role.rb
+++ b/lib/cocina_display/contributors/role.rb
@@ -45,8 +45,6 @@ module CocinaDisplay
         /^funder/i.match? to_s
       end
 
-      private
-
       # The name of the MARC relator role
       # @raises [KeyError] if the role is not valid
       # @return [String, nil]


### PR DESCRIPTION
DataWorks needs access to these to map MARC relator codes to
its own DataCite contributor role schema.

Fixes https://github.com/sul-dlss/dataworks-etl/issues/391
