### PR TITLE
Add helper methods for checking access rights

### DIFF
--- a/lib/cocina_display/concerns/accesses.rb
+++ b/lib/cocina_display/concerns/accesses.rb
@@ -64,6 +64,131 @@ module CocinaDisplay
         end
       end
 
+      # View rights for the object.
+      # @return [String, nil]
+      # @example "world", "stanford_only", "dark", "location-based"
+      def view_rights
+        path("$.access.view").first
+      end
+
+      # Download rights for the object.
+      # @note Individual files may have differing download rights.
+      # @return [String, nil]
+      # @example "world", "stanford_only", "none", "location-based"
+      def download_rights
+        path("$.access.download").first
+      end
+
+      # If access or download is location-based, which location has access.
+      # @return [String, nil]
+      # @example "spec", "music", "ars", "art", "hoover", "m&m"
+      def location_rights
+        path("$.access.location").first
+      end
+
+      # Is the object viewable in some capacity?
+      # @return [Boolean]
+      def viewable?
+        view_rights != "dark"
+      end
+
+      # Is the object downloadable in some capacity?
+      # @return [Boolean]
+      def downloadable?
+        download_rights != "none"
+      end
+
+      # Is the object viewable by anyone?
+      # @return [Boolean]
+      def world_viewable?
+        view_rights == "world"
+      end
+
+      # Is the object downloadable by anyone?
+      # @return [Boolean]
+      def world_downloadable?
+        download_rights == "world"
+      end
+
+      # Is the object both viewable and downloadable by anyone?
+      # @return [Boolean]
+      def world_access?
+        world_viewable? && world_downloadable?
+      end
+
+      # Is the object only viewable by Stanford affiliates?
+      # @return [Boolean]
+      def stanford_only_viewable?
+        view_rights == "stanford"
+      end
+
+      # Is the object only downloadable by Stanford affiliates?
+      # @return [Boolean]
+      def stanford_only_downloadable?
+        download_rights == "stanford"
+      end
+
+      # Is the object only viewable and downloadable by Stanford affiliates?
+      # @return [Boolean]
+      def stanford_only_access?
+        stanford_only_viewable? && stanford_only_downloadable?
+      end
+
+      # Is the object viewable by Stanford affiliates?
+      # @return [Boolean]
+      def stanford_viewable?
+        world_viewable? || stanford_only_viewable?
+      end
+
+      # Is the object downloadable by Stanford affiliates?
+      # @return [Boolean]
+      def stanford_downloadable?
+        world_downloadable? || stanford_only_downloadable?
+      end
+
+      # Is the object both viewable and downloadable by Stanford affiliates?
+      # @return [Boolean]
+      def stanford_access?
+        stanford_viewable? && stanford_downloadable?
+      end
+
+      # Is the object "dark" (not viewable or downloadable by anyone)?
+      # @return [Boolean]
+      def dark_access?
+        !viewable? && !downloadable?
+      end
+
+      # Is the object viewable only if in a location?
+      # @return [Boolean]
+      def location_only_viewable?
+        view_rights == "location-based"
+      end
+
+      # Is the object downloadable only if in a location?
+      # @return [Boolean]
+      def location_only_downloadable?
+        download_rights == "location-based"
+      end
+
+      # Is the object only viewable and downloadable if in a location?
+      # @return [Boolean]
+      def location_only_access?
+        location_only_viewable? && location_only_downloadable?
+      end
+
+      # Is the object viewable at the given location?
+      # @param location [String] The location to check
+      # @return [Boolean]
+      def viewable_at_location?(location)
+        world_viewable? || stanford_viewable? || location_rights == location
+      end
+
+      # Is the object only viewable for citation purposes?
+      # @return [Boolean]
+      def citation_only_access?
+        view_rights == "citation-only"
+      end
+
       private
 
       # The Purl URL to combine with other access metadata

--- a/spec/concerns/accesses_spec.rb
+++ b/spec/concerns/accesses_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       }
     }.to_json
   end
-  let(:record) { described_class.from_json(cocina_json) }
+  subject(:record) { described_class.from_json(cocina_json) }
 
   describe "#access_display_data" do
     it "returns an array of access display data" do
@@ -128,6 +128,170 @@ RSpec.describe CocinaDisplay::CocinaRecord do
           label: "License"
         ))
       )
+    end
+  end
+
+  describe "access rights" do
+    context "dark" do
+      let(:cocina_access) do
+        {
+          "view" => "dark",
+          "download" => "none"
+        }
+      end
+
+      it { is_expected.not_to be_viewable }
+      it { is_expected.not_to be_downloadable }
+      it { is_expected.not_to be_world_access }
+      it { is_expected.not_to be_stanford_access }
+      it { is_expected.not_to be_stanford_only_access }
+      it { is_expected.not_to be_location_only_access }
+      it { is_expected.not_to be_citation_only_access }
+      it { is_expected.to be_dark_access }
+    end
+
+    context "world view and download" do
+      let(:cocina_access) do
+        {
+          "view" => "world",
+          "download" => "world"
+        }
+      end
+
+      it { is_expected.to be_viewable }
+      it { is_expected.to be_downloadable }
+      it { is_expected.to be_world_viewable }
+      it { is_expected.to be_world_downloadable }
+      it { is_expected.to be_world_access }
+      it { is_expected.to be_stanford_access }
+      it { is_expected.to be_stanford_viewable }
+      it { is_expected.to be_stanford_downloadable }
+      it { is_expected.not_to be_stanford_only_access }
+      it { is_expected.not_to be_dark_access }
+      it { is_expected.not_to be_location_only_access }
+      it { is_expected.not_to be_citation_only_access }
+    end
+
+    context "world view, stanford only download" do
+      let(:cocina_access) do
+        {
+          "view" => "world",
+          "download" => "stanford"
+        }
+      end
+
+      it { is_expected.to be_viewable }
+      it { is_expected.to be_downloadable }
+      it { is_expected.to be_world_viewable }
+      it { is_expected.not_to be_world_downloadable }
+      it { is_expected.not_to be_world_access }
+      it { is_expected.to be_stanford_viewable }
+      it { is_expected.to be_stanford_downloadable }
+      it { is_expected.to be_stanford_access }
+      it { is_expected.not_to be_stanford_only_access }
+      it { is_expected.not_to be_dark_access }
+      it { is_expected.not_to be_location_only_access }
+      it { is_expected.not_to be_citation_only_access }
+    end
+
+    context "stanford only view and download" do
+      let(:cocina_access) do
+        {
+          "view" => "stanford",
+          "download" => "stanford"
+        }
+      end
+
+      it { is_expected.to be_viewable }
+      it { is_expected.to be_downloadable }
+      it { is_expected.not_to be_world_viewable }
+      it { is_expected.not_to be_world_downloadable }
+      it { is_expected.not_to be_world_access }
+      it { is_expected.to be_stanford_viewable }
+      it { is_expected.to be_stanford_downloadable }
+      it { is_expected.to be_stanford_access }
+      it { is_expected.to be_stanford_only_access }
+      it { is_expected.not_to be_dark_access }
+      it { is_expected.not_to be_location_only_access }
+      it { is_expected.not_to be_citation_only_access }
+    end
+
+    context "view and download at ars only" do
+      let(:cocina_access) do
+        {
+          "view" => "location-based",
+          "download" => "location-based",
+          "location" => "ars"
+        }
+      end
+
+      it { is_expected.to be_viewable }
+      it { is_expected.to be_downloadable }
+      it { is_expected.not_to be_world_viewable }
+      it { is_expected.not_to be_world_downloadable }
+      it { is_expected.not_to be_world_access }
+      it { is_expected.not_to be_stanford_viewable }
+      it { is_expected.not_to be_stanford_downloadable }
+      it { is_expected.not_to be_stanford_only_access }
+      it { is_expected.not_to be_stanford_access }
+      it { is_expected.not_to be_dark_access }
+      it { is_expected.not_to be_citation_only_access }
+      it { is_expected.to be_location_only_viewable }
+      it { is_expected.to be_location_only_downloadable }
+      it { is_expected.to be_location_only_access }
+      it { is_expected.to be_viewable_at_location("ars") }
+      it { is_expected.not_to be_viewable_at_location("spec") }
+    end
+
+    context "view at spec only, no download" do
+      let(:cocina_access) do
+        {
+          "view" => "location-based",
+          "download" => "none",
+          "location" => "spec"
+        }
+      end
+
+      it { is_expected.to be_viewable }
+      it { is_expected.not_to be_downloadable }
+      it { is_expected.not_to be_world_viewable }
+      it { is_expected.not_to be_world_downloadable }
+      it { is_expected.not_to be_world_access }
+      it { is_expected.not_to be_stanford_viewable }
+      it { is_expected.not_to be_stanford_downloadable }
+      it { is_expected.not_to be_stanford_only_access }
+      it { is_expected.not_to be_stanford_access }
+      it { is_expected.not_to be_dark_access }
+      it { is_expected.to be_location_only_viewable }
+      it { is_expected.not_to be_location_only_downloadable }
+      it { is_expected.not_to be_location_only_access }
+      it { is_expected.not_to be_citation_only_access }
+      it { is_expected.to be_viewable_at_location("spec") }
+      it { is_expected.not_to be_viewable_at_location("ars") }
+    end
+
+    context "citation only" do
+      let(:cocina_access) do
+        {
+          "view" => "citation-only",
+          "download" => "none"
+        }
+      end
+
+      it { is_expected.to be_viewable }
+      it { is_expected.not_to be_downloadable }
+      it { is_expected.not_to be_world_viewable }
+      it { is_expected.not_to be_world_downloadable }
+      it { is_expected.not_to be_world_access }
+      it { is_expected.not_to be_stanford_viewable }
+      it { is_expected.not_to be_stanford_downloadable }
+      it { is_expected.not_to be_stanford_only_access }
+      it { is_expected.not_to be_dark_access }
+      it { is_expected.not_to be_stanford_access }
+      it { is_expected.not_to be_location_only_viewable }
+      it { is_expected.not_to be_location_only_downloadable }
+      it { is_expected.not_to be_location_only_access }
+      it { is_expected.to be_citation_only_access }
     end
   end
 


### PR DESCRIPTION
This adds a big group of helper methods for checking the access
rights of an object. You can check whether the object has a given
permission, or whether it is limited to a certain set of people.

Closes #206
