### PR TITLE
Handle missing start/end dates in Cocina date ranges

### DIFF
--- a/lib/cocina_display/concerns/events.rb
+++ b/lib/cocina_display/concerns/events.rb
@@ -12,19 +12,13 @@ module CocinaDisplay
         return unless (date = pub_date(ignore_qualified: ignore_qualified))
 
         if date.is_a? CocinaDisplay::Dates::DateRange
-          if !date.start.date.is_a? EDTF::Unknown
-            edtf_date = date.start.date
-          elsif !date.stop.date.is_a? EDTF::Unknown
-            edtf_date = date.stop.date
-          end
-        else
-          edtf_date = date.date
+          date = date.start&.known? ? date.start : date.stop
         end
 
-        return if edtf_date.is_a? EDTF::Unknown
-        return edtf_date.from if edtf_date.is_a?(EDTF::Interval)
+        return unless date&.known?
+        return date.date.from if date.date.is_a?(EDTF::Interval)
 
-        edtf_date
+        date.date
       end
 
       # The earliest preferred publication year as an integer.

--- a/lib/cocina_display/dates/date.rb
+++ b/lib/cocina_display/dates/date.rb
@@ -143,6 +143,12 @@ module CocinaDisplay
         qualifier.present?
       end
 
+      # Does this represent a known date?
+      # @return [Boolean]
+      def known?
+        !date.is_a?(EDTF::Unknown)
+      end
+
       # Was an encoding declared for this date?
       # @return [Boolean]
       def encoding?

--- a/spec/concerns/events_spec.rb
+++ b/spec/concerns/events_spec.rb
@@ -258,6 +258,40 @@ RSpec.describe CocinaDisplay::CocinaRecord do
 
       it { is_expected.to eq(1868) }
     end
+
+    context "with a date range with no start" do
+      let(:dates) do
+        [
+          {
+            "structuredValue" => [
+              {"value" => "1948", "type" => "end", "status" => "primary"}
+            ],
+            "type" => "creation",
+            "encoding" => {"code" => "w3cdtf"},
+            "qualifier" => "approximate"
+          }
+        ]
+      end
+
+      it { is_expected.to eq(1948) }
+    end
+
+    context "with a date range with no end" do
+      let(:dates) do
+        [
+          {
+            "structuredValue" => [
+              {"value" => "2001", "type" => "start", "status" => "primary"}
+            ],
+            "type" => "creation",
+            "encoding" => {"code" => "w3cdtf"},
+            "qualifier" => "approximate"
+          }
+        ]
+      end
+
+      it { is_expected.to eq(2001) }
+    end
   end
 
   describe "#pub_year_int_range" do


### PR DESCRIPTION
This adds a #known? accessor that makes it slightly simpler to
throw out unknown dates, both in ranges and for single dates.

Fixes #212
