### PR TITLE
Productionize CocinaRecord.fetch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gemspec
 
 gem "irb"
 gem "debug", "~> 1.11"
+gem "webmock", "~> 3.26"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,12 +25,17 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -48,6 +53,7 @@ GEM
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
     geo_coord (0.2.0)
+    hashdiff (1.2.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)
@@ -74,6 +80,7 @@ GEM
     psych (5.2.6)
       date
       stringio
+    public_suffix (7.0.0)
     purl_fetcher-client (3.1.0)
       activesupport
       faraday (~> 2.1)
@@ -86,6 +93,7 @@ GEM
     regexp_parser (2.11.2)
     reline (0.6.2)
       io-console (~> 0.5)
+    rexml (3.4.4)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -146,6 +154,10 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     uri (1.0.3)
+    webmock (3.26.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.1)
     yard (0.9.37)
     zeitwerk (2.7.3)
@@ -165,6 +177,7 @@ DEPENDENCIES
   simplecov (~> 0.22.0)
   simplecov-rspec (~> 0.4)
   standard (~> 1.3)
+  webmock (~> 3.26)
   webrick (~> 1.9, >= 1.9.1)
   yard (~> 0.9.37)
 

--- a/lib/cocina_display/cocina_record.rb
+++ b/lib/cocina_display/cocina_record.rb
@@ -18,16 +18,14 @@ module CocinaDisplay
     include CocinaDisplay::Concerns::RelatedResources
 
     # Fetch a public Cocina document from PURL and create a CocinaRecord.
-    # @note This is intended to be used in development or testing only.
     # @param druid [String] The bare DRUID of the object to fetch.
     # @param purl_url [String] The base url for the purl service.
     # @param deep_compact [Boolean] If true, compact the JSON to remove blank values.
     # @return [CocinaDisplay::CocinaRecord]
-    # :nocov:
     def self.fetch(druid, deep_compact: true, purl_url: "https://purl.stanford.edu")
-      from_json(Net::HTTP.get(URI("#{purl_url}/#{druid}.json")), deep_compact: deep_compact)
+      response = Net::HTTP.get_response(URI("#{purl_url}/#{druid}.json"))
+      from_json(response.body, deep_compact: deep_compact) if response.is_a?(Net::HTTPSuccess)
     end
-    # :nocov:
 
     # Create a CocinaRecord from a JSON string.
     # @param cocina_json [String]

--- a/spec/cocina_record_spec.rb
+++ b/spec/cocina_record_spec.rb
@@ -9,6 +9,30 @@ RSpec.describe CocinaDisplay::CocinaRecord do
 
   subject { described_class.new(cocina_doc) }
 
+  describe "#fetch" do
+    before do
+      stub_request(:get, "https://purl.stanford.edu/#{druid}.json")
+        .to_return(body: cocina_json, status: 200)
+    end
+
+    it "fetches and returns a CocinaRecord" do
+      record = described_class.fetch(druid)
+      expect(record).to be_a(described_class)
+    end
+
+    context "when the object has no public cocina" do
+      before do
+        stub_request(:get, "https://purl.stanford.edu/#{druid}.json")
+          .to_return(status: 404)
+      end
+
+      it "returns nil" do
+        record = described_class.fetch(druid)
+        expect(record).to be_nil
+      end
+    end
+  end
+
   describe "#content_type" do
     let(:druid) { "bx658jh7339" }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "rspec"
 require "simplecov"
 require "simplecov-rspec"
 require "debug"
+require "webmock/rspec"
 
 # Ignore coverage if running a single file; otherwise turn it on
 if RSpec.configuration.files_to_run.count > 1


### PR DESCRIPTION
This makes the method handle missing objects more gracefully,
and behave the same way it's used in searchworks_traject_indexer.
