### PR TITLE
Exclude publishers from contributor_display_data

### DIFF
--- a/lib/cocina_display/concerns/contributors.rb
+++ b/lib/cocina_display/concerns/contributors.rb
@@ -80,11 +80,11 @@ module CocinaDisplay
         end
       end
 
-      # DisplayData for Contributors, one per role.
+      # DisplayData for Contributors, one per role (excluding publisher).
       # Contributors with no role are grouped under a default heading.
       # @return [Array<DisplayData>]
       def contributor_display_data
-        contributors_by_role.map do |role, contributors|
+        contributors_by_role.except("publisher").map do |role, contributors|
           label = I18n.t(role, scope: "cocina_display.contributor.role",
             default: role&.capitalize || I18n.t("default", scope: "cocina_display.contributor.role"))
           DisplayData.new(label: label, objects: contributors)

--- a/spec/concerns/contributors_spec.rb
+++ b/spec/concerns/contributors_spec.rb
@@ -659,9 +659,6 @@ RSpec.describe CocinaDisplay::CocinaRecord do
             have_attributes(label: "Editor", values: ["Smith, Jane"])
           ),
           be_a(CocinaDisplay::DisplayData).and(
-            have_attributes(label: "Publisher", values: ["ACME Corp"])
-          ),
-          be_a(CocinaDisplay::DisplayData).and(
             have_attributes(label: "Engraver", values: ["Lasinio, Carlo, 1759-1838"])
           )
         )


### PR DESCRIPTION
I don't know of any cases where we want to include publishers with other contributors for display purposes.