### PR TITLE
Alias CocinaRecord#folio_hrid to #catkey

### DIFF
--- a/lib/cocina_display/concerns/identifiers.rb
+++ b/lib/cocina_display/concerns/identifiers.rb
@@ -53,6 +53,7 @@ module CocinaDisplay
 
         (link["refresh"] == refresh) ? hrid : nil
       end
+      alias_method :catkey, :folio_hrid
 
       # The FOLIO HRID if defined, otherwise the bare DRUID.
       # @note This doesn't imply the object is available in Searchworks at this ID.


### PR DESCRIPTION
searchworks_traject_indexer uses this method name.
