### PR TITLE
Add helper methods for retrieving authors and their names

### DIFF
--- a/lib/cocina_display/concerns/contributors.rb
+++ b/lib/cocina_display/concerns/contributors.rb
@@ -27,6 +27,12 @@ module CocinaDisplay
         publisher_contributors.flat_map(&:display_names).compact
       end
 
+      # All names of authors, formatted for display.
+      # @return [Array<String>]
+      def author_names
+        author_contributors.flat_map(&:display_names).compact
+      end
+
       # All names of contributors who are people, formatted for display.
       # @param with_date [Boolean] Include life dates, if present
       # @return [Array<String>]
@@ -109,6 +115,13 @@ module CocinaDisplay
           path("$.description.contributor.*"),
           path("$.description.event.*.contributor.*")
         ).map { |c| CocinaDisplay::Contributors::Contributor.new(c) }
+      end
+
+      # All contributors with an "author" role.
+      # @return [Array<Contributor>]
+      # @see Contributor#author?
+      def author_contributors
+        contributors.filter(&:author?)
       end
 
       # All contributors with a "publisher" role.

--- a/spec/concerns/contributors_spec.rb
+++ b/spec/concerns/contributors_spec.rb
@@ -812,6 +812,47 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     end
   end
 
+  describe "#author_names" do
+    subject { record.author_names }
+
+    context "with author contributors" do
+      let(:contributors) do
+        [
+          {
+            "name" => [{"value" => "Doe, John"}],
+            "role" => [{"value" => "author"}],
+            "type" => "person"
+          },
+          {
+            "name" => [{"value" => "John Smith"}],
+            "role" => [{"code" => "aut", "source" => {"code" => "marcrelator"}}],
+            "type" => "person"
+          },
+          {
+            "name" => [{"value" => "Smith, Jane"}],
+            "role" => [{"value" => "editor"}],
+            "type" => "person"
+          }
+        ]
+      end
+      it { is_expected.to eq(["Doe, John", "John Smith"]) }
+    end
+
+    context "with no author contributors" do
+      let(:contributors) do
+        [
+          {
+            "name" => [{"value" => "ACME Corp"}],
+            "role" => [{"value" => "publisher"}],
+            "type" => "organization"
+          }
+        ]
+      end
+
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe "contributor ORCIDs and affiliations" do
     # from druid:cz537wr8540
     let(:cocina_json) do


### PR DESCRIPTION
Earthworks indexing uses the names of authors only, rather than
all contributors.
