### PR TITLE
Prevent generation of download URLs for collections and related resources

### DIFF
--- a/lib/cocina_display/concerns/url_helpers.rb
+++ b/lib/cocina_display/concerns/url_helpers.rb
@@ -26,11 +26,12 @@ module CocinaDisplay
 
       # The download URL to get the entire object as a .zip file.
       # Stacks generates the .zip for the object on request.
+      # @note Collections do not have a download URL.
       # @return [String]
       # @example
       #   record.download_url #=> "https://stacks.stanford.edu/object/bx658jh7339"
       def download_url
-        "#{stacks_base_url}/object/#{bare_druid}" if bare_druid.present?
+        "#{stacks_base_url}/object/#{bare_druid}" if is_a?(CocinaDisplay::CocinaRecord) && bare_druid.present? && !collection?
       end
 
       # The IIIF manifest URL for the object.

--- a/spec/concerns/url_helpers_spec.rb
+++ b/spec/concerns/url_helpers_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         expect(subject.download_url).to eq "https://sul-stacks-stage.stanford.edu/object/qr918wy2257"
       end
     end
+
+    context "for a collection" do
+      let(:druid) { "nz187ct8959" }
+
+      it "returns nil" do
+        expect(subject.download_url).to be_nil
+      end
+    end
   end
 
   describe "#iiif_manifest_url" do

--- a/spec/related_resource_spec.rb
+++ b/spec/related_resource_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe CocinaDisplay::RelatedResource do
       describe "#download_url" do
         subject { described_class.new(cocina_doc).download_url }
 
-        it { is_expected.to eq "https://stacks.stanford.edu/object/xx111yy2223" }
+        it { is_expected.to be_nil }
       end
 
       describe "#iiif_manifest_url" do


### PR DESCRIPTION
Neither of these kinds of things can be downloaded via stacks. Related resources _might_ be able to, but we have no way of knowing if they are collections or not, so can't guarantee it.
