### PR TITLE
Make form methods consider geographic forms as well

### DIFF
--- a/lib/cocina_display/concerns/forms.rb
+++ b/lib/cocina_display/concerns/forms.rb
@@ -75,10 +75,16 @@ module CocinaDisplay
       end
 
       # All form notes to be rendered for display.
+      # Checks both description.form.note and description.geographic.form.note.
       # @return [Array<DisplayData>]
       def form_note_display_data
-        CocinaDisplay::DisplayData.from_cocina(path("$.description.form[*].note[*]"),
-          label: I18n.t("cocina_display.field_label.form.note"))
+        CocinaDisplay::DisplayData.from_cocina(
+          Enumerator::Chain.new(
+            path("$.description.form.*.note.*"),
+            path("$.description.geographic.*.form.*.note.*")
+          ),
+          label: I18n.t("cocina_display.field_label.form.note")
+        )
       end
 
       # Is the object a periodical or serial?
@@ -106,10 +112,14 @@ module CocinaDisplay
       end
 
       # Collapses all nested form values into an array of {Form} objects.
+      # Checks both description.form and description.geographic.form.
       # Preserves resource type without flattening, since it can be structured.
       # @return [Array<Form>]
       def all_forms
-        @all_forms ||= path("$.description.form.*")
+        @all_forms ||= Enumerator::Chain.new(
+          path("$.description.form.*"),
+          path("$.description.geographic.*.form.*")
+        )
           .flat_map { |form| Utils.flatten_nested_values(form, atomic_types: ["resource type"]) }
           .map { |form| CocinaDisplay::Forms::Form.from_cocina(form) }
       end

--- a/spec/concerns/forms_spec.rb
+++ b/spec/concerns/forms_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe CocinaDisplay::CocinaRecord do
   let(:forms) { [] }
   let(:events) { [] }
   let(:subjects) { [] }
+  let(:geographic) { [] }
   let(:cocina_json) do
     {
       "description" => {
         "form" => forms,
         "event" => events,
-        "subject" => subjects
+        "subject" => subjects,
+        "geographic" => geographic
       }
     }.to_json
   end
@@ -152,6 +154,23 @@ RSpec.describe CocinaDisplay::CocinaRecord do
 
       it "extracts the individual form values" do
         is_expected.to eq(["audiotape reel"])
+      end
+    end
+
+    context "when the forms are in the geographic section" do
+      let(:geographic) do
+        [
+          {
+            "form" => [
+              {"value" => "topographic map", "type" => "form"},
+              {"value" => "aerial photograph", "type" => "form"}
+            ]
+          }
+        ]
+      end
+
+      it "includes those form values as well" do
+        is_expected.to eq(["topographic map", "aerial photograph"])
       end
     end
   end


### PR DESCRIPTION
Our subject methods check the description.geographic section for
subjects, but the form methods didn't do that. This fixes that.

Earthworks indexing uses some of these form values to check what
download format the item will use.
