### PR TITLE
Don't error when trying to get content type of empty objects

### DIFF
--- a/lib/cocina_display/cocina_record.rb
+++ b/lib/cocina_display/cocina_record.rb
@@ -51,13 +51,12 @@ module CocinaDisplay
     end
 
     # SDR content type of the object.
-    # @note {RelatedResource}s may not have a content type.
     # @return [String, nil]
     # @see https://github.com/sul-dlss/cocina-models/blob/main/openapi.yml#L532-L546
     # @example
     #  record.content_type #=> "image"
     def content_type
-      cocina_doc["type"].delete_prefix("https://cocina.sul.stanford.edu/models/")
+      cocina_doc["type"]&.delete_prefix("https://cocina.sul.stanford.edu/models/")
     end
 
     # Primary processing label for the object.

--- a/spec/cocina_record_spec.rb
+++ b/spec/cocina_record_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     it "returns the content type from the cocina document" do
       expect(subject.content_type).to eq "image"
     end
+
+    context "with a stub object" do
+      let(:cocina_doc) { {} }
+
+      it "returns nil" do
+        expect(subject.content_type).to be_nil
+      end
+    end
   end
 
   describe "#collection?" do


### PR DESCRIPTION
In some cases we have a stub object or no JSON at all; in that
case returning nil is better than throwing a cryptic error.
