### PR TITLE
Do not include event contributors in contributor methods

### DIFF
--- a/lib/cocina_display/concerns/contributors.rb
+++ b/lib/cocina_display/concerns/contributors.rb
@@ -108,13 +108,11 @@ module CocinaDisplay
       end
 
       # All contributors for the object, including authors, editors, etc.
-      # Checks both description.contributor and description.event.contributor.
+      # @note Does not include contributors attached to events.
       # @return [Array<Contributor>]
       def contributors
-        @contributors ||= Enumerator::Chain.new(
-          path("$.description.contributor.*"),
-          path("$.description.event.*.contributor.*")
-        ).map { |c| CocinaDisplay::Contributors::Contributor.new(c) }
+        @contributors ||= path("$.description.contributor.*")
+          .map { |c| CocinaDisplay::Contributors::Contributor.new(c) }
       end
 
       # All contributors with an "author" role.
@@ -147,13 +145,7 @@ module CocinaDisplay
       # @return [Array<Contributor>]
       def additional_contributors
         return [] if contributors.empty? || contributors.one?
-        contributors.reject { |c| imprint_contributors.include?(c) } - [main_contributor]
-      end
-
-      # The contributors associated with imprint events (usually publishers).
-      # @return [Array<Contributor>]
-      def imprint_contributors
-        imprint_events.flat_map(&:contributors).uniq
+        contributors - [main_contributor]
       end
     end
   end

--- a/spec/concerns/contributors_spec.rb
+++ b/spec/concerns/contributors_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         }.to_json
       end
 
-      it "does not include the event contributor in additional contributors" do
+      it "does not include the event contributor" do
         is_expected.to eq([
           "Gabbay, Yehezkel",
           "Jerusalmi, Isaac",
@@ -909,8 +909,8 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         }.to_json
       end
 
-      it "returns the publisher from the event" do
-        is_expected.to eq(["Chronicle Books"])
+      it "does not use the event contributor" do
+        is_expected.to be_empty
       end
     end
   end


### PR DESCRIPTION
This much broader solution to #229 was inspired by Slack conversation
with Arcadia. Keeping event contributors separated from contributors
makes things simpler; because of how the fields evolved over time
there is not enough consistency to justify grouping them together.

Fixes #229.
