### PR TITLE
Add a method for getting a string of the Contributor's roles

### DIFF
--- a/lib/cocina_display/contributors/contributor.rb
+++ b/lib/cocina_display/contributors/contributor.rb
@@ -72,6 +72,13 @@ module CocinaDisplay
         roles.any?
       end
 
+      # String representation of the contributor's role(s).
+      # @return [String, nil]
+      # @example "author, editor, publisher"
+      def display_role
+        roles.map(&:to_s).join(", ") if role?
+      end
+
       # The primary display name for the contributor as a string.
       # @param with_date [Boolean] Include life dates, if present
       # @return [String, nil]

--- a/spec/contributor_spec.rb
+++ b/spec/contributor_spec.rb
@@ -193,6 +193,36 @@ RSpec.describe CocinaDisplay::Contributors::Contributor do
     end
   end
 
+  describe "#display_role" do
+    subject { instance.display_role }
+
+    context "with no roles" do
+      let(:cocina) { {} }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with one role" do
+      let(:cocina) do
+        {
+          "role" => [{"value" => "author"}]
+        }
+      end
+
+      it { is_expected.to eq "author" }
+    end
+
+    context "with multiple roles" do
+      let(:cocina) do
+        {
+          "role" => [{"value" => "author"}, {"value" => "editor"}, {"value" => "publisher"}]
+        }
+      end
+
+      it { is_expected.to eq "author, editor, publisher" }
+    end
+  end
+
   describe "#conference?" do
     subject { instance.conference? }
 


### PR DESCRIPTION
Searchworks indexing uses this to populate the author_struct field
so that it can construct smart links for faceting.
