### PR TITLE
Support filtering identifier by type

### DIFF
--- a/lib/cocina_display/concerns/identifiers.rb
+++ b/lib/cocina_display/concerns/identifiers.rb
@@ -64,10 +64,12 @@ module CocinaDisplay
         folio_hrid || bare_druid
       end
 
-      # Identifier objects extracted from the Cocina metadata.
+      # All identifier objects, optionally filtered by type.
+      # @param type [String, nil] The type of identifier to filter by (e.g. "DOI").
+      # @note Type matching is case insensitive.
       # @return [Array<Identifier>]
-      def identifiers
-        @identifiers ||= path("$.description.identifier[*]").map { |id| Identifier.new(id) } + Array(doi_from_identification)
+      def identifiers(type: nil)
+        type.present? ? all_identifiers.filter { |id| id.type&.casecmp?(type) } : all_identifiers
       end
 
       # Labelled display data for identifiers.
@@ -77,6 +79,12 @@ module CocinaDisplay
       end
 
       private
+
+      # All identifier objects extracted from the Cocina metadata.
+      # @return [Array<Identifier>]
+      def all_identifiers
+        @identifiers ||= path("$.description.identifier[*]").map { |id| Identifier.new(id) } + Array(doi_from_identification)
+      end
 
       # Synthetic Identifier object for a DOI in the identification block.
       # @return [Array<Identifier>]

--- a/spec/concerns/identifiers_spec.rb
+++ b/spec/concerns/identifiers_spec.rb
@@ -262,4 +262,75 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       )
     end
   end
+
+  describe "#identifiers" do
+    subject { described_class.new(cocina_doc) }
+
+    let(:cocina_doc) do
+      {
+        "identification" => {
+          "doi" => "identification-doi"
+        },
+        "description" => {
+          "identifier" => [
+            {
+              "type" => "doi",
+              "value" => "10.25740/ppax-bf07"
+            },
+            {
+              "type" => "doi",
+              "value" => "https://doi.org/10.25740/sb4q-wj06"
+            },
+            {
+              "type" => "isbn",
+              "value" => "978-0-061-96436-7"
+            },
+            {
+              "type" => "other",
+              "value" => "other-id-123"
+            },
+            {
+              "type" => "other",
+              "value" => "other-id-123"
+            },
+            {
+              "type" => "other",
+              "value" => ""
+            },
+            {
+              "type" => "lccn",
+              "value" => ""
+            },
+            {
+              "type" => "other",
+              "value" => "other-id-456"
+            },
+            {
+              "type" => "custom",
+              "value" => "custom-id-123",
+              "displayLabel" => "Custom label"
+            }
+          ]
+        }
+      }
+    end
+
+    it "returns all identifiers when no type is given" do
+      expect(subject.identifiers.size).to eq 10
+    end
+
+    it "returns all identifiers of a given type when specified" do
+      dois = subject.identifiers(type: "doi")
+      expect(dois.map(&:identifier)).to contain_exactly(
+        "10.25740/ppax-bf07",
+        "10.25740/sb4q-wj06",
+        "identification-doi"
+      )
+    end
+
+    it "is case insensitive when filtering by type" do
+      isbns = subject.identifiers(type: "ISBN")
+      expect(isbns.map(&:identifier)).to contain_exactly("978-0-061-96436-7")
+    end
+  end
 end


### PR DESCRIPTION
This is a convenience for the Searchworks indexing config, which
needs to fetch ISSNs, ISBNs, etc.
