### PR TITLE
Add a method to generate IIIF URLs for thumbnails

### DIFF
--- a/lib/cocina_display/concerns/structural.rb
+++ b/lib/cocina_display/concerns/structural.rb
@@ -58,11 +58,12 @@ module CocinaDisplay
         files.map(&:size).compact.sum
       end
 
-      # The thumbnail file for this object, if any.
-      # Prefers files marked as thumbnails; falls back to any JP2 image.
-      # @return [CocinaDisplay::Structural::File, nil]
-      def thumbnail_file
-        files.find(&:thumbnail?) || files.find(&:jp2_image?)
+      # URL to a thumbnail image for this object, if any.
+      # @note Uses the IIIF image server to generate an image of the given size.
+      # @return [String, nil]
+      # @example "https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204.jp2/full/400,400/0/default.jpg"
+      def thumbnail_url(base_url: stacks_base_url, height: 400, width: 400)
+        thumbnail_file&.iiif_url(base_url: base_url, height: height, width: width)
       end
 
       # True if the object has a usable thumbnail file.
@@ -101,6 +102,13 @@ module CocinaDisplay
       # @example "hj097bm8879"
       def virtual_object_parents
         related_resources.filter { |res| res.type == "part of" }.map(&:druid).compact_blank
+      end
+
+      # The thumbnail file for this object, if any.
+      # Prefers files marked as thumbnails; falls back to any JP2 image.
+      # @return [CocinaDisplay::Structural::File, nil]
+      def thumbnail_file
+        files.find(&:thumbnail?) || files.find(&:jp2_image?)
       end
     end
   end

--- a/lib/cocina_display/structural/file.rb
+++ b/lib/cocina_display/structural/file.rb
@@ -68,6 +68,40 @@ module CocinaDisplay
       def width
         cocina.dig("presentation", "width").to_i
       end
+
+      # Generate a IIIF image URL for this file.
+      # @param base_url [String] Base URL for the IIIF image server.
+      # @param height [Integer] Desired height of the image in pixels.
+      # @param width [Integer] Desired width of the image in pixels.
+      # @return [String, nil]
+      # @example "https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204.jp2/full/400,400/0/default.jpg"
+      def iiif_url(base_url:, height: 400, width: 400)
+        return unless base_url.present? && iiif_id.present?
+
+        "#{base_url}/image/iiif/#{iiif_id}/full/!#{width},#{height}/0/default.jpg"
+      end
+
+      # For images served over IIIF, we encode the DRUID and filename as an identifier.
+      # @return [String, nil]
+      # @example "ts786ny5936%2FPC0170_s1_E_0204"
+      def iiif_id
+        ERB::Util.url_encode("#{druid}/#{filename.delete_suffix(".jp2")}") if druid.present? && filename.present?
+      end
+
+      private
+
+      # External identifier for the file, including the DRUID and file ID.
+      # @return [String, nil]
+      # @example "ts786ny5936-ts786ny5936_1/PC0170_s1_E_0204.jp2"
+      def external_id
+        cocina["externalIdentifier"]&.delete_prefix("https://cocina.sul.stanford.edu/file/")
+      end
+
+      # The DRUID of the object this file belongs to.
+      # @return [String, nil]
+      def druid
+        external_id.split("-").first if external_id.present?
+      end
     end
   end
 end

--- a/spec/concerns/structural_spec.rb
+++ b/spec/concerns/structural_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     end
   end
 
-  describe "#thumbnail_file" do
+  describe "#thumbnail_url" do
     context "when there is a file marked for thumbnail use" do
       let(:druid) { "bc798xr9549" }
 
       it "returns the thumbnail file" do
-        expect(subject.thumbnail_file.filename).to eq("bc798xr9549_30C_Kalsang_Yulgial_thumb.jp2")
+        expect(subject.thumbnail_url).to eq("https://stacks.stanford.edu/image/iiif/bc798xr9549%2Fbc798xr9549_30C_Kalsang_Yulgial_thumb/full/!400,400/0/default.jpg")
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       let(:druid) { "bk264hq9320" }
 
       it "returns the first jp2 image file" do
-        expect(subject.thumbnail_file.filename).to eq("bk264hq9320_img_1.jp2")
+        expect(subject.thumbnail_url).to eq("https://stacks.stanford.edu/image/iiif/bk264hq9320%2Fbk264hq9320_img_1/full/!400,400/0/default.jpg")
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       end
 
       it "returns nil" do
-        expect(subject.thumbnail_file).to be_nil
+        expect(subject.thumbnail_url).to be_nil
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       let(:druid) { "ws947mh3822" }
 
       it "returns nil" do
-        expect(subject.thumbnail_file).to be_nil
+        expect(subject.thumbnail_url).to be_nil
       end
     end
   end


### PR DESCRIPTION
This logic had lived in Searchworks's indexer, but it seems more
useful to let any application request it.

Things got a little complicated because each File didn't know its
druid, and we were trying to construct IIIF URLs using them. This
lets the File itself handle all of that.
