### PR TITLE
Add a #preferred_citation helper

### DIFF
--- a/lib/cocina_display/concerns/notes.rb
+++ b/lib/cocina_display/concerns/notes.rb
@@ -20,6 +20,13 @@ module CocinaDisplay
         notes.select(&:table_of_contents?).map(&:to_s).compact_blank
       end
 
+      # Preferred citation for the object.
+      # If there are multiple notes with this type, uses the first.
+      # @return [String, nil]
+      def preferred_citation
+        notes.find(&:preferred_citation?)&.to_s
+      end
+
       # Abstract metadata for display.
       # @return [Array<CocinaDisplay::DisplayData>]
       def abstract_display_data

--- a/spec/concerns/notes_spec.rb
+++ b/spec/concerns/notes_spec.rb
@@ -82,6 +82,21 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     end
   end
 
+  describe "#preferred_citation" do
+    subject { record.preferred_citation }
+
+    let(:notes) do
+      [
+        {value: "This is a note"},
+        {value: "This is a citation", type: "preferred citation"}
+      ]
+    end
+
+    it "returns the preferred citation note text" do
+      expect(subject).to eq "This is a citation"
+    end
+  end
+
   describe "#abstract_display_data" do
     subject { record.abstract_display_data }
 


### PR DESCRIPTION
We had the DisplayData version of this, but not a simple string
method for indexing purposes. Used for Searchworks.
