### PR TITLE
Add optional region parameter to thumbnail_url method

### DIFF
--- a/lib/cocina_display/concerns/structural.rb
+++ b/lib/cocina_display/concerns/structural.rb
@@ -60,10 +60,14 @@ module CocinaDisplay
 
       # URL to a thumbnail image for this object, if any.
       # @note Uses the IIIF image server to generate an image of the given size.
+      # @param base_url [String] Base URL for the IIIF image server.
+      # @param region [String] Desired region of the image (e.g., "full", "square", "x,y,w,h", "pct:x,y,w,h").
+      # @param width [String] Desired width of the image in pixels (use "!" prefix to preserve aspect ratio).
+      # @param height [String] Desired height of the image in pixels.
       # @return [String, nil]
-      # @example "https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204.jp2/full/400,400/0/default.jpg"
-      def thumbnail_url(base_url: stacks_base_url, height: 400, width: 400)
-        thumbnail_file&.iiif_url(base_url: base_url, height: height, width: width)
+      # @example "https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204.jp2/full/!400,400/0/default.jpg"
+      def thumbnail_url(base_url: stacks_base_url, region: "full", width: "!400", height: "400")
+        thumbnail_file&.iiif_url(base_url: base_url, region: region, width: width, height: height)
       end
 
       # True if the object has a usable thumbnail file.

--- a/lib/cocina_display/structural/file.rb
+++ b/lib/cocina_display/structural/file.rb
@@ -71,14 +71,15 @@ module CocinaDisplay
 
       # Generate a IIIF image URL for this file.
       # @param base_url [String] Base URL for the IIIF image server.
-      # @param height [Integer] Desired height of the image in pixels.
-      # @param width [Integer] Desired width of the image in pixels.
+      # @param region [String] Desired region of the image (e.g., "full", "square", "x,y,w,h", "pct:x,y,w,h").
+      # @param width [String] Desired width of the image in pixels (use "!" prefix to preserve aspect ratio).
+      # @param height [String] Desired height of the image in pixels.
       # @return [String, nil]
-      # @example "https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204.jp2/full/400,400/0/default.jpg"
-      def iiif_url(base_url:, height: 400, width: 400)
+      # @example "https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204.jp2/full/!400,400/0/default.jpg"
+      def iiif_url(base_url:, region: "full", width: "!400", height: "400")
         return unless base_url.present? && iiif_id.present?
 
-        "#{base_url}/image/iiif/#{iiif_id}/full/!#{width},#{height}/0/default.jpg"
+        "#{base_url}/image/iiif/#{iiif_id}/#{region}/#{width},#{height}/0/default.jpg"
       end
 
       # For images served over IIIF, we encode the DRUID and filename as an identifier.

--- a/spec/concerns/structural_spec.rb
+++ b/spec/concerns/structural_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       it "returns the thumbnail file" do
         expect(subject.thumbnail_url).to eq("https://stacks.stanford.edu/image/iiif/bc798xr9549%2Fbc798xr9549_30C_Kalsang_Yulgial_thumb/full/!400,400/0/default.jpg")
       end
+
+      it "allows optional parameters for region, width, and height" do
+        expect(subject.thumbnail_url(region: "square", width: "200", height: "200")).to eq("https://stacks.stanford.edu/image/iiif/bc798xr9549%2Fbc798xr9549_30C_Kalsang_Yulgial_thumb/square/200,200/0/default.jpg")
+      end
     end
 
     context "when there is no marked file, but there are jp2 images" do


### PR DESCRIPTION
Exhibits needs to set region to `square` in some cases. Also:
- moves the `!` preserve aspect ratio prefix on the width into the parameter
- flips the order of the height and width parameters to match the order in the IIIF URL