### PR TITLE
Add file download URLs; ensure file URLs respect environment

### DIFF
--- a/lib/cocina_display/concerns/structural.rb
+++ b/lib/cocina_display/concerns/structural.rb
@@ -14,7 +14,7 @@ module CocinaDisplay
       #  end
       def filesets
         @filesets ||= path("$.structural.contains.*").map do |fileset|
-          CocinaDisplay::Structural::FileSet.new(fileset)
+          CocinaDisplay::Structural::FileSet.new(fileset, druid: bare_druid, base_url: stacks_base_url)
         end
       end
 
@@ -60,14 +60,13 @@ module CocinaDisplay
 
       # URL to a thumbnail image for this object, if any.
       # @note Uses the IIIF image server to generate an image of the given size.
-      # @param base_url [String] Base URL for the IIIF image server.
       # @param region [String] Desired region of the image (e.g., "full", "square", "x,y,w,h", "pct:x,y,w,h").
       # @param width [String] Desired width of the image in pixels (use "!" prefix to preserve aspect ratio).
       # @param height [String] Desired height of the image in pixels.
       # @return [String, nil]
       # @example "https://stacks.stanford.edu/image/iiif/ts786ny5936%2FPC0170_s1_E_0204.jp2/full/!400,400/0/default.jpg"
-      def thumbnail_url(base_url: stacks_base_url, region: "full", width: "!400", height: "400")
-        thumbnail_file&.iiif_url(base_url: base_url, region: region, width: width, height: height)
+      def thumbnail_url(region: "full", width: "!400", height: "400")
+        thumbnail_file&.iiif_url(region: region, width: width, height: height)
       end
 
       # True if the object has a usable thumbnail file.

--- a/lib/cocina_display/structural/file_set.rb
+++ b/lib/cocina_display/structural/file_set.rb
@@ -5,10 +5,17 @@ module CocinaDisplay
       # Underlying hash parsed from Cocina JSON.
       attr_reader :cocina
 
+      # URL to Stacks environment that will serve this fileset.
+      attr_reader :base_url
+
       # Initialize the FileSet with Cocina structural data.
       # @param cocina [Hash] Cocina structured data for a single FileSet
-      def initialize(cocina)
+      # @param base_url [String] URL to Stacks environment that will serve this fileset
+      # @param druid [String, nil] DRUID of the object this fileset belongs to
+      def initialize(cocina, base_url: "https://stacks.stanford.edu", druid: nil)
         @cocina = cocina
+        @base_url = base_url
+        @druid = druid
       end
 
       # The declared type of the FileSet, like "image" or "document".
@@ -21,7 +28,29 @@ module CocinaDisplay
       # All files contained in this FileSet.
       # @return [Array<CocinaDisplay::Structural::File>]
       def files
-        Array(cocina.dig("structural", "contains")).map { |file| CocinaDisplay::Structural::File.new(file) }
+        @files ||= Array(cocina.dig("structural", "contains")).map do |file|
+          CocinaDisplay::Structural::File.new(file, base_url: base_url, druid: druid)
+        end
+      end
+
+      private
+
+      # DRUID of the object this fileset belongs to.
+      # @note Inferred from the start of the externalIdentifier.
+      # @return [String, nil]
+      def druid
+        @druid || external_id[/^[a-z]{2}\d{3}[a-z]{2}\d{4}/] if external_id.present?
+      end
+
+      # External identifier for the fileset, minus the URL prefix.
+      # @return [String, nil]
+      # @note Staging and production formats differ.
+      # @example production
+      #   "bk264hq9320-bk264hq9320_3"
+      # @example staging
+      #   "bh114dk3076_4"
+      def external_id
+        cocina["externalIdentifier"]&.delete_prefix("https://cocina.sul.stanford.edu/fileSet/")
       end
     end
   end

--- a/spec/concerns/structural_spec.rb
+++ b/spec/concerns/structural_spec.rb
@@ -180,4 +180,12 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       end
     end
   end
+
+  context "with a staging object" do
+    let(:druid) { "bh114dk3076" }
+
+    it "generates file download URLs from stacks staging environment" do
+      expect(subject.files.first.download_url).to eq("https://sul-stacks-stage.stanford.edu/file/druid:bh114dk3076/README.md")
+    end
+  end
 end

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -1,0 +1,73 @@
+require "spec_helper"
+
+RSpec.describe CocinaDisplay::Structural::File do
+  subject { described_class.new(cocina) }
+
+  describe "#download_url" do
+    let(:cocina) do
+      {
+        "externalIdentifier" => "https://cocina.sul.stanford.edu/file/bc798xr9549-bc798xr9549_3/bc798xr9549_30C_Kalsang_Yulgial_img.jp2",
+        "filename" => "bc798xr9549_30C_Kalsang_Yulgial_img.jp2"
+      }
+    end
+
+    it "generates a download URL for the file" do
+      expect(subject.download_url).to eq("https://stacks.stanford.edu/file/druid:bc798xr9549/bc798xr9549_30C_Kalsang_Yulgial_img.jp2")
+    end
+  end
+
+  describe "#iiif_url" do
+    context "with a jp2 image with height and width" do
+      let(:cocina) do
+        {
+          "type" => "https://cocina.sul.stanford.edu/models/file",
+          "externalIdentifier" => "https://cocina.sul.stanford.edu/file/bc798xr9549-bc798xr9549_3/bc798xr9549_30C_Kalsang_Yulgial_img.jp2",
+          "hasMimeType" => "image/jp2",
+          "filename" => "bc798xr9549_30C_Kalsang_Yulgial_img.jp2",
+          "presentation" => {
+            "height" => 2100,
+            "width" => 1500
+          }
+        }
+      end
+
+      it "generates a IIIF image URL for the file" do
+        expect(subject.iiif_url).to eq("https://stacks.stanford.edu/image/iiif/bc798xr9549%2Fbc798xr9549_30C_Kalsang_Yulgial_img/full/!400,400/0/default.jpg")
+      end
+    end
+
+    context "with a non-jp2 file" do
+      let(:cocina) do
+        {
+          "type" => "https://cocina.sul.stanford.edu/models/file",
+          "externalIdentifier" => "https://cocina.sul.stanford.edu/file/bc798xr9549-bc798xr9549_3/bc798xr9549_30C_Kalsang_Yulgial_img.jpg",
+          "filename" => "bc798xr9549_30C_Kalsang_Yulgial_img.jpg",
+          "hasMimeType" => "image/jpeg",
+          "presentation" => {
+            "height" => 2100,
+            "width" => 1500
+          }
+        }
+      end
+
+      it "returns nil" do
+        expect(subject.iiif_url).to be_nil
+      end
+    end
+
+    context "with an image without height or width" do
+      let(:cocina) do
+        {
+          "type" => "https://cocina.sul.stanford.edu/models/file",
+          "externalIdentifier" => "https://cocina.sul.stanford.edu/file/bc798xr9549-bc798xr9549_3/bc798xr9549_30C_Kalsang_Yulgial_img.jp2",
+          "filename" => "bc798xr9549_30C_Kalsang_Yulgial_img.jp2",
+          "hasMimeType" => "image/jp2"
+        }
+      end
+
+      it "returns nil" do
+        expect(subject.iiif_url).to be_nil
+      end
+    end
+  end
+end

--- a/spec/fixtures/fn851zf9475.json
+++ b/spec/fixtures/fn851zf9475.json
@@ -1,1 +1,328 @@
-{"cocinaVersion":"0.75.0","type":"https://cocina.sul.stanford.edu/models/image","externalIdentifier":"druid:fn851zf9475","label":"Thomas Bros. map of Palo Alto and vicinity including Redwood City, Atherton, Menlo Park, Los Altos, and Mountain View","version":7,"access":{"view":"world","download":"world","controlledDigitalLending":false,"useAndReproductionStatement":"Property rights reside with the repository. Literary rights reside with  the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc)."},"administrative":{"hasAdminPolicy":"druid:yf767bj4831"},"description":{"title":[{"value":"Thomas Bros. map of Palo Alto and vicinity including Redwood City, Atherton, Menlo Park, Los Altos, and Mountain View"}],"event":[{"date":[{"value":"1930","type":"creation","status":"primary","encoding":{"code":"w3cdtf"},"qualifier":"approximate"}]}],"form":[{"value":"Maps","type":"genre","uri":"http://id.loc.gov/authorities/genreForms/gf2011026387","source":{"code":"lcgft","uri":"http://id.loc.gov/authorities/genreForms/"}},{"value":"cartographic","type":"resource type","source":{"value":"MODS resource types"}},{"value":"printed","type":"form"},{"value":"image/jpeg","type":"media type","source":{"value":"IANA media types"}},{"value":"1 sheet, 31 x 24 in.","type":"extent"},{"value":"reformatted digital","type":"digital origin","source":{"value":"MODS digital origin terms"}}],"geographic":[{"form":[{"value":"image/jpeg","type":"media type","source":{"value":"IANA media type terms"}},{"value":"Image","type":"media type","source":{"value":"DCMI Type Vocabulary"}}],"subject":[{"structuredValue":[{"value":"-122.241615","type":"west"},{"value":"37.301368","type":"south"},{"value":"-122.004381","type":"east"},{"value":"37.418939","type":"north"}],"type":"bounding box coordinates","encoding":{"value":"decimal"}}]}],"language":[{"code":"eng","source":{"code":"iso639-2b","uri":"http://id.loc.gov/vocabulary/iso639-2"},"uri":"http://id.loc.gov/vocabulary/iso639-2/eng","value":"English"}],"note":[{"value":"On verso:  Thomas Bros. Map of San Jose, Santa Clara, and Vicinity.","displayLabel":"Abstract"},{"value":"Digitized by Stanford University Libraries."}],"identifier":[{"value":"sc1049_m522_0001","type":"local","source":{"code":"local"},"displayLabel":"Source ID"}],"subject":[{"value":"Thomas Brothers","type":"organization","uri":"http://id.loc.gov/authorities/names/n80036596","source":{"code":"naf","uri":"http://id.loc.gov/authorities/names/"}},{"value":"Palo Alto (Calif.)","type":"place","uri":"http://id.loc.gov/authorities/names/n81019888","source":{"code":"lcsh","uri":"http://id.loc.gov/authorities/names/"}},{"value":"San Jose (Calif.)","type":"place","uri":"http://id.loc.gov/authorities/names/n79102890","source":{"code":"lcsh","uri":"http://id.loc.gov/authorities/names/"}},{"value":"Santa Clara County (Calif.)","type":"place","uri":"http://id.loc.gov/authorities/names/n50046557","source":{"code":"lcsh","uri":"http://id.loc.gov/authorities/names/"}},{"value":"W 122°14'29\"--W 122°00'15\"/N 37°31'01\"--N 37°21'15\"","type":"map coordinates"}],"access":{"physicalLocation":[{"value":"Series: Miscellaneous Stanford University Maps (mostly non-campus)","type":"series"},{"value":"SC1049, Map case Na1, Map number 522_0001","type":"shelf locator"}],"accessContact":[{"value":"Stanford University. Libraries. Department of Special Collections and University Archives","type":"repository","uri":"http://id.loc.gov/authorities/names/no2014019980","source":{"code":"naf"}}]},"relatedResource":[{"type":"part of","displayLabel":"Series","title":[{"value":"Miscellaneous Stanford University Maps (mostly non-campus)"}]},{"type":"part of","displayLabel":"Appears in","title":[{"value":"[Thomas Bros. maps of Palo Alto, San Jose, Santa Clara and vicinities]"}],"purl":"https://purl.stanford.edu/dg050kz7339"}],"adminMetadata":{"contributor":[{"name":[{"code":"CSt","source":{"code":"marcorg"}}],"type":"organization","role":[{"value":"original cataloging agency"}]}],"language":[{"code":"eng","source":{"code":"iso639-2b","uri":"http://id.loc.gov/vocabulary/iso639-2"},"uri":"http://id.loc.gov/vocabulary/iso639-2/eng"}]},"purl":"https://purl.stanford.edu/fn851zf9475"},"identification":{"sourceId":"sul:sc1049_m522_0001"},"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/resources/image","externalIdentifier":"https://cocina.sul.stanford.edu/fileSet/fn851zf9475-fn851zf9475_1","label":"Image 1","version":7,"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/file","externalIdentifier":"https://cocina.sul.stanford.edu/file/fn851zf9475-fn851zf9475_1/fn851zf9475_00_0001.jp2","label":"fn851zf9475_00_0001.jp2","filename":"fn851zf9475_00_0001.jp2","size":62871825,"version":7,"hasMimeType":"image/jp2","sdrGeneratedText":false,"correctedForAccessibility":false,"hasMessageDigests":[{"type":"sha1","digest":"af6d2aff722b244e2f958e8c1aa9c4a492e0eb7f"},{"type":"md5","digest":"0e1669b87a49feaca0ac43f15de8711d"}],"access":{"view":"world","download":"world","controlledDigitalLending":false},"administrative":{"publish":true,"sdrPreserve":false,"shelve":true},"presentation":{"height":20372,"width":16381}}]}}],"isMemberOf":["druid:fh138mm2023"]},"created":"2014-09-22T21:39:48.000+00:00","modified":"2024-06-12T19:42:58.000+00:00","lock":"druid:fn851zf9475=0=1"}
+{
+  "cocinaVersion": "0.75.0",
+  "type": "https://cocina.sul.stanford.edu/models/image",
+  "externalIdentifier": "druid:fn851zf9475",
+  "label": "Thomas Bros. map of Palo Alto and vicinity including Redwood City, Atherton, Menlo Park, Los Altos, and Mountain View",
+  "version": 7,
+  "access": {
+    "view": "world",
+    "download": "world",
+    "controlledDigitalLending": false,
+    "useAndReproductionStatement": "Property rights reside with the repository. Literary rights reside with  the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc)."
+  },
+  "administrative": {
+    "hasAdminPolicy": "druid:yf767bj4831"
+  },
+  "description": {
+    "title": [
+      {
+        "value": "Thomas Bros. map of Palo Alto and vicinity including Redwood City, Atherton, Menlo Park, Los Altos, and Mountain View"
+      }
+    ],
+    "event": [
+      {
+        "date": [
+          {
+            "value": "1930",
+            "type": "creation",
+            "status": "primary",
+            "encoding": {
+              "code": "w3cdtf"
+            },
+            "qualifier": "approximate"
+          }
+        ]
+      }
+    ],
+    "form": [
+      {
+        "value": "Maps",
+        "type": "genre",
+        "uri": "http://id.loc.gov/authorities/genreForms/gf2011026387",
+        "source": {
+          "code": "lcgft",
+          "uri": "http://id.loc.gov/authorities/genreForms/"
+        }
+      },
+      {
+        "value": "cartographic",
+        "type": "resource type",
+        "source": {
+          "value": "MODS resource types"
+        }
+      },
+      {
+        "value": "printed",
+        "type": "form"
+      },
+      {
+        "value": "image/jpeg",
+        "type": "media type",
+        "source": {
+          "value": "IANA media types"
+        }
+      },
+      {
+        "value": "1 sheet, 31 x 24 in.",
+        "type": "extent"
+      },
+      {
+        "value": "reformatted digital",
+        "type": "digital origin",
+        "source": {
+          "value": "MODS digital origin terms"
+        }
+      }
+    ],
+    "geographic": [
+      {
+        "form": [
+          {
+            "value": "image/jpeg",
+            "type": "media type",
+            "source": {
+              "value": "IANA media type terms"
+            }
+          },
+          {
+            "value": "Image",
+            "type": "media type",
+            "source": {
+              "value": "DCMI Type Vocabulary"
+            }
+          }
+        ],
+        "subject": [
+          {
+            "structuredValue": [
+              {
+                "value": "-122.241615",
+                "type": "west"
+              },
+              {
+                "value": "37.301368",
+                "type": "south"
+              },
+              {
+                "value": "-122.004381",
+                "type": "east"
+              },
+              {
+                "value": "37.418939",
+                "type": "north"
+              }
+            ],
+            "type": "bounding box coordinates",
+            "encoding": {
+              "value": "decimal"
+            }
+          }
+        ]
+      }
+    ],
+    "language": [
+      {
+        "code": "eng",
+        "source": {
+          "code": "iso639-2b",
+          "uri": "http://id.loc.gov/vocabulary/iso639-2"
+        },
+        "uri": "http://id.loc.gov/vocabulary/iso639-2/eng",
+        "value": "English"
+      }
+    ],
+    "note": [
+      {
+        "value": "On verso:  Thomas Bros. Map of San Jose, Santa Clara, and Vicinity.",
+        "displayLabel": "Abstract"
+      },
+      {
+        "value": "Digitized by Stanford University Libraries."
+      }
+    ],
+    "identifier": [
+      {
+        "value": "sc1049_m522_0001",
+        "type": "local",
+        "source": {
+          "code": "local"
+        },
+        "displayLabel": "Source ID"
+      }
+    ],
+    "subject": [
+      {
+        "value": "Thomas Brothers",
+        "type": "organization",
+        "uri": "http://id.loc.gov/authorities/names/n80036596",
+        "source": {
+          "code": "naf",
+          "uri": "http://id.loc.gov/authorities/names/"
+        }
+      },
+      {
+        "value": "Palo Alto (Calif.)",
+        "type": "place",
+        "uri": "http://id.loc.gov/authorities/names/n81019888",
+        "source": {
+          "code": "lcsh",
+          "uri": "http://id.loc.gov/authorities/names/"
+        }
+      },
+      {
+        "value": "San Jose (Calif.)",
+        "type": "place",
+        "uri": "http://id.loc.gov/authorities/names/n79102890",
+        "source": {
+          "code": "lcsh",
+          "uri": "http://id.loc.gov/authorities/names/"
+        }
+      },
+      {
+        "value": "Santa Clara County (Calif.)",
+        "type": "place",
+        "uri": "http://id.loc.gov/authorities/names/n50046557",
+        "source": {
+          "code": "lcsh",
+          "uri": "http://id.loc.gov/authorities/names/"
+        }
+      },
+      {
+        "value": "W 122°14'29\"--W 122°00'15\"/N 37°31'01\"--N 37°21'15\"",
+        "type": "map coordinates"
+      }
+    ],
+    "access": {
+      "physicalLocation": [
+        {
+          "value": "Series: Miscellaneous Stanford University Maps (mostly non-campus)",
+          "type": "series"
+        },
+        {
+          "value": "SC1049, Map case Na1, Map number 522_0001",
+          "type": "shelf locator"
+        }
+      ],
+      "accessContact": [
+        {
+          "value": "Stanford University. Libraries. Department of Special Collections and University Archives",
+          "type": "repository",
+          "uri": "http://id.loc.gov/authorities/names/no2014019980",
+          "source": {
+            "code": "naf"
+          }
+        }
+      ]
+    },
+    "relatedResource": [
+      {
+        "type": "part of",
+        "displayLabel": "Series",
+        "title": [
+          {
+            "value": "Miscellaneous Stanford University Maps (mostly non-campus)"
+          }
+        ]
+      },
+      {
+        "type": "part of",
+        "displayLabel": "Appears in",
+        "title": [
+          {
+            "value": "[Thomas Bros. maps of Palo Alto, San Jose, Santa Clara and vicinities]"
+          }
+        ],
+        "purl": "https://purl.stanford.edu/dg050kz7339"
+      }
+    ],
+    "adminMetadata": {
+      "contributor": [
+        {
+          "name": [
+            {
+              "code": "CSt",
+              "source": {
+                "code": "marcorg"
+              }
+            }
+          ],
+          "type": "organization",
+          "role": [
+            {
+              "value": "original cataloging agency"
+            }
+          ]
+        }
+      ],
+      "language": [
+        {
+          "code": "eng",
+          "source": {
+            "code": "iso639-2b",
+            "uri": "http://id.loc.gov/vocabulary/iso639-2"
+          },
+          "uri": "http://id.loc.gov/vocabulary/iso639-2/eng"
+        }
+      ]
+    },
+    "purl": "https://purl.stanford.edu/fn851zf9475"
+  },
+  "identification": {
+    "sourceId": "sul:sc1049_m522_0001"
+  },
+  "structural": {
+    "contains": [
+      {
+        "type": "https://cocina.sul.stanford.edu/models/resources/image",
+        "externalIdentifier": "https://cocina.sul.stanford.edu/fileSet/fn851zf9475-fn851zf9475_1",
+        "label": "Image 1",
+        "version": 7,
+        "structural": {
+          "contains": [
+            {
+              "type": "https://cocina.sul.stanford.edu/models/file",
+              "externalIdentifier": "https://cocina.sul.stanford.edu/file/fn851zf9475-fn851zf9475_1/fn851zf9475_00_0001.jp2",
+              "label": "fn851zf9475_00_0001.jp2",
+              "filename": "fn851zf9475_00_0001.jp2",
+              "size": 62871825,
+              "version": 7,
+              "hasMimeType": "image/jp2",
+              "sdrGeneratedText": false,
+              "correctedForAccessibility": false,
+              "hasMessageDigests": [
+                {
+                  "type": "sha1",
+                  "digest": "af6d2aff722b244e2f958e8c1aa9c4a492e0eb7f"
+                },
+                {
+                  "type": "md5",
+                  "digest": "0e1669b87a49feaca0ac43f15de8711d"
+                }
+              ],
+              "access": {
+                "view": "world",
+                "download": "world",
+                "controlledDigitalLending": false
+              },
+              "administrative": {
+                "publish": true,
+                "sdrPreserve": false,
+                "shelve": true
+              },
+              "presentation": {
+                "height": 20372,
+                "width": 16381
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "isMemberOf": [
+      "druid:fh138mm2023"
+    ]
+  },
+  "created": "2014-09-22T21:39:48.000+00:00",
+  "modified": "2024-06-12T19:42:58.000+00:00",
+  "lock": "druid:fn851zf9475=0=1"
+}


### PR DESCRIPTION
This adds a file download URL helper and refactors the structural
classes so that they can correctly infer their DRUID and generate
links to the appropriate environment.

Because staging objects have differently formatted FileSets and
Files, they may not know the DRUID of the object they belong to,
and they certainly don't know that they should point to the
staging stacks environment. This handles that by passing the
information that can't be inferred from the parent class.
