### PR TITLE
Update Searchworks ISO639 language map

### DIFF
--- a/config/searchworks_languages.yml
+++ b/config/searchworks_languages.yml
@@ -1,7 +1,8 @@
 # Map of language codes to language names used in Searchworks, ported from stanford-mods gem.
 # See: https://github.com/solrmarc/stanford-solr-marc/blob/master/stanford-sw/translation_maps/language_map.properties
 
-aaa: Afar
+#???: null
+aar: Afar
 abk: Abkhaz
 ace: Achinese
 ach: Acoli
@@ -11,7 +12,8 @@ afa: Afroasiatic (Other)
 afh: Afrihili (Artificial language)
 afr: Afrikaans
 ain: Ainu
-ajm: Aljamia
+# ajm is deprecated
+ajm: Aljamía
 aka: Akan
 akk: Akkadian
 alb: Albanian
@@ -24,12 +26,13 @@ anp: Angika
 apa: Apache languages
 ara: Arabic
 arc: Aramaic
-arg: Aragonese Spanish
+arg: Aragonese
 arm: Armenian
 arn: Mapuche
 arp: Arapaho
 art: Artificial (Other)
 arw: Arawak
+# ase from iso639-3
 ase: American Sign Language
 asm: Assamese
 ast: Bable
@@ -40,7 +43,7 @@ ave: Avestan
 awa: Awadhi
 aym: Aymara
 aze: Azerbaijani
-bad: Banda
+bad: Banda languages
 bai: Bamileke languages
 bak: Bashkir
 bal: Baluchi
@@ -55,7 +58,7 @@ bem: Bemba
 ben: Bengali
 ber: Berber (Other)
 bho: Bhojpuri
-bih: Bihari
+bih: Bihari (Other)
 bik: Bikol
 bin: Edo
 bis: Bislama
@@ -72,6 +75,7 @@ bur: Burmese
 byn: Bilin
 cad: Caddo
 cai: Central American Indian (Other)
+# cam is deprecated
 cam: Khmer
 car: Carib
 cat: Catalan
@@ -83,7 +87,7 @@ chb: Chibcha
 che: Chechen
 chg: Chagatai
 chi: Chinese
-chk: Truk
+chk: Chuukese
 chm: Mari
 chn: Chinook jargon
 cho: Choctaw
@@ -93,6 +97,7 @@ chu: Church Slavic
 chv: Chuvash
 chy: Cheyenne
 cmc: Chamic languages
+cnr: Montenegrin
 cop: Coptic
 cor: Cornish
 cos: Corsican
@@ -110,7 +115,7 @@ dan: Danish
 dar: Dargwa
 day: Dayak
 del: Delaware
-den: Slave
+den: Slavey
 dgr: Dogrib
 din: Dinka
 div: Divehi
@@ -130,14 +135,18 @@ elx: Elamite
 eng: English
 enm: English, Middle (1100-1500)
 epo: Esperanto
+# esk is deprecated
 esk: Eskimo languages
+# esp is deprecated
 esp: Esperanto
 est: Estonian
+# eth is deprecated
 eth: Ethiopic
 ewe: Ewe
 ewo: Ewondo
 fan: Fang
 fao: Faroese
+# far is deprecated
 far: Faroese
 fat: Fanti
 fij: Fijian
@@ -146,17 +155,21 @@ fin: Finnish
 fiu: Finno-Ugrian (Other)
 fon: Fon
 fre: French
+# fri is deprecated
 fri: Frisian
-frm: French, Middle (ca. 1400-1600)
-fro: French, Old (ca. 842-1400)
+frm: French, Middle (ca. 1300-1600)
+fro: French, Old (ca. 842-1300)
 frr: North Frisian
 frs: East Frisian
 fry: Frisian
 ful: Fula
 fur: Friulian
-gaa: Ga
+gaa: Gã
+# gae is deprecated
 gae: Scottish Gaelic
+# gag is deprecated
 gag: Galician
+# gal is deprecated
 gal: Oromo
 gay: Gayo
 gba: Gbaya
@@ -176,12 +189,13 @@ gor: Gorontalo
 got: Gothic
 grb: Grebo
 grc: Greek, Ancient (to 1453)
-gre: Greek, Modern (1453- )
+gre: Greek, Modern (1453-)
 grn: Guarani
 gsw: Swiss German
+# gua is deprecated
 gua: Guarani
 guj: Gujarati
-gwi: Gwich'in 
+gwi: Gwich'in
 hai: Haida
 hat: Haitian French Creole
 hau: Hausa
@@ -189,7 +203,7 @@ haw: Hawaiian
 heb: Hebrew
 her: Herero
 hil: Hiligaynon
-him: Himachali
+him: Western Pahari languages
 hin: Hindi
 hit: Hittite
 hmn: Hmong
@@ -212,9 +226,11 @@ inc: Indic (Other)
 ind: Indonesian
 ine: Indo-European (Other)
 inh: Ingush
+# int is deprecated
 int: Interlingua (International Auxiliary Language Association)
 ipk: Inupiaq
 ira: Iranian (Other)
+# iri is deprecated
 iri: Irish
 iro: Iroquoian (Other)
 ita: Italian
@@ -226,10 +242,10 @@ jrb: Judeo-Arabic
 kaa: Kara-Kalpak
 kab: Kabyle
 kac: Kachin
-kal: Kalatdlisut
+kal: Kalâtdlisut
 kam: Kamba
 kan: Kannada
-kar: Karen
+kar: Karen languages
 kas: Kashmiri
 kau: Kanuri
 kaw: Kawi
@@ -247,22 +263,25 @@ kok: Konkani
 kom: Komi
 kon: Kongo
 kor: Korean
-kos: Kusaie
+kos: Kosraean
 kpe: Kpelle
 krc: Karachay-Balkar
 krl: Karelian
-kro: Kru
+kro: Kru (Other)
 kru: Kurukh
 kua: Kuanyama
 kum: Kumyk
 kur: Kurdish
+# kus is deprecated
 kus: Kusaie
-kut: Kutenai
+kut: Kootenai
 lad: Ladino
-lah: Lahnda
-lam: Lamba
-lan: Occitan (post-1500)
+lah: Lahndā
+lam: Lamba (Zambia and Congo)
+# lan is deprecated
+lan: Occitan (post 1500)
 lao: Lao
+# lap is deprecated
 lap: Sami
 lat: Latin
 lav: Latvian
@@ -272,11 +291,11 @@ lin: Lingala
 lit: Lithuanian
 lol: Mongo-Nkundu
 loz: Lozi
-ltz: Letzeburgesch
+ltz: Luxembourgish
 lua: Luba-Lulua
 lub: Luba-Katanga
 lug: Ganda
-lui: Luiseno
+lui: Luiseño
 lun: Lunda
 luo: Luo (Kenya and Tanzania)
 lus: Lushai
@@ -291,7 +310,8 @@ man: Mandingo
 mao: Maori
 map: Austronesian (Other)
 mar: Marathi
-mas: Masai
+mas: Maasai
+# max is deprecated
 max: Manx
 may: Malay
 mdf: Moksha
@@ -300,8 +320,9 @@ men: Mende
 mga: Irish, Middle (ca. 1100-1550)
 mic: Micmac
 min: Minangkabau
-# mis: Miscellaneous languages
+mis: Miscellaneous languages
 mkh: Mon-Khmer (Other)
+# mla is deprecated
 mla: Malagasy
 mlg: Malagasy
 mlt: Maltese
@@ -309,10 +330,11 @@ mnc: Manchu
 mni: Manipuri
 mno: Manobo languages
 moh: Mohawk
+# mol is deprecated
 mol: Moldavian
 mon: Mongolian
-mos: Moore
-# mul: Multiple languages
+mos: Mooré
+mul: Multiple languages
 mun: Munda (Other)
 mus: Creek
 mwl: Mirandese
@@ -334,7 +356,7 @@ nia: Nias
 nic: Niger-Kordofanian (Other)
 niu: Niuean
 nno: Norwegian (Nynorsk)
-nob: Norwegian (Bokmal)
+nob: Norwegian (Bokmål)
 nog: Nogai
 non: Old Norse
 nor: Norwegian
@@ -368,10 +390,10 @@ phi: Philippine (Other)
 phn: Phoenician
 pli: Pali
 pol: Polish
-pon: Ponape
+pon: Pohnpeian
 por: Portuguese
 pra: Prakrit languages
-pro: Provencal (to 1500)
+pro: Provençal (to 1500)
 pus: Pushto
 que: Quechua
 raj: Rajasthani
@@ -391,18 +413,22 @@ sai: South American Indian (Other)
 sal: Salishan languages
 sam: Samaritan Aramaic
 san: Sanskrit
+# sao is deprecated
 sao: Samoan
 sas: Sasak
 sat: Santali
+# scc is deprecated
 scc: Serbian
 scn: Sicilian Italian
 sco: Scots
+# scr is deprecated
 scr: Croatian
 sel: Selkup
 sem: Semitic (Other)
 sga: Irish, Old (to 1100)
 sgn: Sign languages
 shn: Shan
+# sho is deprecated
 sho: Shona
 sid: Sidamo
 sin: Sinhalese
@@ -420,6 +446,7 @@ smo: Samoan
 sms: Skolt Sami
 sna: Shona
 snd: Sindhi
+# snh is deprecated
 snh: Sinhalese
 snk: Soninke
 sog: Sogdian
@@ -432,6 +459,7 @@ srn: Sranan
 srp: Serbian
 srr: Serer
 ssa: Nilo-Saharan (Other)
+# sso is deprecated
 sso: Sotho
 ssw: Swazi
 suk: Sukuma
@@ -440,14 +468,18 @@ sus: Susu
 sux: Sumerian
 swa: Swahili
 swe: Swedish
+# swz is deprecated
 swz: Swazi
 syc: Syriac
 syr: Syriac, Modern
+# tag is deprecated
 tag: Tagalog
 tah: Tahitian
 tai: Tai (Other)
+# taj is deprecated
 taj: Tajik
 tam: Tamil
+# tar is deprecated
 tar: Tatar
 tat: Tatar
 tel: Telugu
@@ -458,7 +490,7 @@ tgk: Tajik
 tgl: Tagalog
 tha: Thai
 tib: Tibetan
-tig: Tigre
+tig: Tigré
 tir: Tigrinya
 tiv: Tiv
 tkl: Tokelauan
@@ -468,10 +500,12 @@ tmh: Tamashek
 tog: Tonga (Nyasa)
 ton: Tongan
 tpi: Tok Pisin
+# tru is deprecated
 tru: Truk
 tsi: Tsimshian
 tsn: Tswana
 tso: Tsonga
+# tsw is deprecated
 tsw: Tswana
 tuk: Turkmen
 tum: Tumbuka
@@ -486,23 +520,22 @@ uga: Ugaritic
 uig: Uighur
 ukr: Ukrainian
 umb: Umbundu
-# und: Undetermined
 urd: Urdu
 uzb: Uzbek
 vai: Vai
 ven: Venda
 vie: Vietnamese
-vol: Volapuk
+vol: Volapük
 vot: Votic
 wak: Wakashan languages
-wal: Walamo
+wal: Wolayta
 war: Waray
-was: Washo
+was: Washoe
 wel: Welsh
-wen: Sorbian languages
+wen: Sorbian (Other)
 wln: Walloon
 wol: Wolof
-xal: Kalmyk
+xal: Oirat
 xho: Xhosa
 yao: Yao (Africa)
 yap: Yapese
@@ -513,7 +546,7 @@ zap: Zapotec
 zbl: Blissymbolics
 zen: Zenaga
 zha: Zhuang
-znd: Zande
+znd: Zande languages
 zul: Zulu
 zun: Zuni
 # zxx: null

--- a/spec/concerns/languages_spec.rb
+++ b/spec/concerns/languages_spec.rb
@@ -98,14 +98,12 @@ RSpec.describe CocinaDisplay::CocinaRecord do
   end
 
   describe "#language_display_data" do
-    subject { record.language_display_data }
+    subject { CocinaDisplay::DisplayData.to_hash(record.language_display_data) }
 
     context "with no languages" do
       let(:languages) { [] }
 
-      it "returns an empty array" do
-        expect(subject).to eq []
-      end
+      it { is_expected.to be_nil }
     end
 
     context "with one language lacking a value" do
@@ -115,9 +113,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         ]
       end
 
-      it "returns an empty array" do
-        expect(subject).to eq []
-      end
+      it { is_expected.to be_nil }
     end
 
     context "with languages" do
@@ -135,9 +131,9 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       end
 
       it "returns display data for each language with duplicates removed" do
-        expect(subject).to contain_exactly(
-          be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Language", values: ["English", "Spanish", "Egyptian, Demotic"])),
-          be_a(CocinaDisplay::DisplayData).and(have_attributes(label: "Primary language", values: ["Sumerian"]))
+        expect(subject).to eq(
+          "Language" => ["English", "Spanish", "Egyptian, Demotic"],
+          "Primary language" => ["Sumerian"]
         )
       end
     end


### PR DESCRIPTION
This updates the language name map based on the changes from
the PR https://github.com/sul-dlss/searchworks_traject_indexer/pull/734.
