### PR TITLE
Fix range checking for imprint date deduplication

### DIFF
--- a/lib/cocina_display/events/imprint.rb
+++ b/lib/cocina_display/events/imprint.rb
@@ -23,7 +23,7 @@ module CocinaDisplay
       # The date portion of the imprint statement, comprising all unique dates.
       # @return [String]
       def date_str
-        Utils.compact_and_join(unique_dates_for_display.map(&:qualified_value))
+        Utils.compact_and_join(unique_dates_for_display.map(&:qualified_value), delimiter: "; ")
       end
 
       # The editions portion of the imprint statement, combining all edition notes.
@@ -71,7 +71,7 @@ module CocinaDisplay
         # Remove any ranges that duplicate part of an unencoded non-range date
         ranges, singles = deduped_dates.partition { |date| date.is_a?(CocinaDisplay::Dates::DateRange) }
         unencoded_singles_dates = singles.reject(&:encoding?).flat_map(&:to_a)
-        ranges.reject! { |range| unencoded_singles_dates.any? { |date| range.as_interval.include?(date) } }
+        ranges.reject! { |date_range| unencoded_singles_dates.any? { |date| date_range.as_range.include?(date) } }
 
         (singles + ranges).sort
       end

--- a/spec/imprint_spec.rb
+++ b/spec/imprint_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe CocinaDisplay::Events::Imprint do
         }
       end
 
-      it "concatenates all valid dates" do
-        is_expected.to eq "no date here 18th century September 1920"
+      it "concatenates and orders all valid dates" do
+        is_expected.to eq "no date here; 18th century; September 1920"
       end
     end
 
@@ -86,6 +86,44 @@ RSpec.describe CocinaDisplay::Events::Imprint do
 
       it "renders the range" do
         is_expected.to eq "1920 - 1921"
+      end
+    end
+
+    # from druid:zs247rr8237
+    context "with two distinct dates" do
+      let(:cocina) do
+        {
+          "date" => [
+            {
+              "value" => "1674",
+              "type" => "creation",
+              "status" => "primary",
+              "qualifier" => "approximate"
+            },
+            {
+              "structuredValue" => [
+                {
+                  "value" => "1690",
+                  "type" => "end"
+                }
+              ],
+              "type" => "creation",
+              "encoding" => {
+                "code" => "w3cdtf"
+              },
+              "qualifier" => "approximate"
+            }
+          ],
+          "location" => [
+            {
+              "value" => "[Italy?]"
+            }
+          ]
+        }
+      end
+
+      it "lists them separately, in order" do
+        is_expected.to eq "[Italy?], [ca. 1674]; [ca. - 1690]"
       end
     end
   end


### PR DESCRIPTION
DateRange#as_interval existed only for the purposes of deduplicating
dates in imprint statements, but it could throw errors on items with
open-ended ranges.

This removes #as_interval in favor of just using #as_range, which
supports the same #include? behavior and is more robust.

Also adds a test to confirm that we're sorting and formatting imprint
statements with multiple dates correctly.
