### PR TITLE
Return points formatted for Solr RPT fields

### DIFF
--- a/lib/cocina_display/concerns/geospatial.rb
+++ b/lib/cocina_display/concerns/geospatial.rb
@@ -30,11 +30,11 @@ module CocinaDisplay
         coordinate_objects.map(&:as_envelope).compact.uniq
       end
 
-      # All valid coordinate data formatted for indexing into a Solr LatLon field.
+      # All valid coordinate data formatted for indexing into a Solr RPT field.
       # @note Bounding boxes are automatically converted to their center point.
       # @see https://solr.apache.org/guide/solr/latest/query-guide/spatial-search.html#indexing-points
       # @return [Array<String>]
-      # @example ["34.0522,-118.2437"]
+      # @example ["-118.2437 34.0522"]
       def coordinates_as_point
         coordinate_objects.map(&:as_point).uniq
       end

--- a/lib/cocina_display/geospatial.rb
+++ b/lib/cocina_display/geospatial.rb
@@ -130,12 +130,12 @@ module CocinaDisplay
         nil
       end
 
-      # Format as a comma-separated latitude,longitude pair.
+      # Format as a space-separated x y (longitude latitude) pair.
       # @note Limits decimals to 6 places.
-      # @example "34.0522,-118.2437"
+      # @example "-118.2437 34.0522"
       # @return [String]
       def as_point
-        "%.6f,%.6f" % [point.lat, point.lng]
+        "%.6f %.6f" % [point.lng, point.lat]
       end
     end
 
@@ -205,15 +205,15 @@ module CocinaDisplay
         ]
       end
 
-      # The box center point as a comma-separated latitude,longitude pair.
+      # The box center point as a space-separated x y (longitude latitude) pair.
       # @note Limits decimals to 6 places.
-      # @example "34.0522,-118.2437"
+      # @example "-118.2437 34.0522"
       # @return [String]
       def as_point
         azimuth = min_point.azimuth(max_point)
         distance = min_point.distance(max_point)
         center = min_point.endpoint(distance / 2, azimuth)
-        "%.6f,%.6f" % [center.lat, center.lng]
+        "%.6f %.6f" % [center.lng, center.lat]
       end
     end
 

--- a/spec/concerns/geospatial_spec.rb
+++ b/spec/concerns/geospatial_spec.rb
@@ -502,12 +502,12 @@ RSpec.describe CocinaDisplay::CocinaRecord do
 
       subject { cocina_record.coordinates_as_point }
 
-      it "returns the point in Solr LatLon format" do
-        expect(subject[0]).to eq("36.740468,-121.246580")
+      it "returns the point in Solr RPT format" do
+        expect(subject[0]).to eq("-121.246580 36.740468")
       end
 
-      it "returns the box center in Solr LatLon format" do
-        expect(subject[1]).to eq("37.188545,-120.652546")
+      it "returns the box center in Solr RPT format" do
+        expect(subject[1]).to eq("-120.652546 37.188545")
       end
     end
   end


### PR DESCRIPTION
Both Solr's RPT field type (`SpatialRecursivePrefixTreeFieldType`) and Blacklight Heatmap require that points are formatted space separate `x y` (`lon lat`).