### PR TITLE
Account for case where the start or stop date is unknown

### DIFF
--- a/lib/cocina_display/dates/date.rb
+++ b/lib/cocina_display/dates/date.rb
@@ -407,6 +407,8 @@ module CocinaDisplay
         return nil if date.nil?
 
         case date_range
+        when EDTF::Unknown
+          nil
         when EDTF::Epoch, EDTF::Interval, EDTF::Season
           date_range.min
         when EDTF::Set
@@ -427,6 +429,8 @@ module CocinaDisplay
         return nil if date.nil?
 
         case date_range
+        when EDTF::Unknown
+          nil
         when EDTF::Epoch, EDTF::Interval, EDTF::Season
           date_range.max
         when EDTF::Set

--- a/spec/concerns/events_spec.rb
+++ b/spec/concerns/events_spec.rb
@@ -449,6 +449,46 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         is_expected.to eq((2000..Date.today.year).to_a)
       end
     end
+
+    context "with an unknown end date" do
+      let(:dates) do
+        [
+          {
+            "structuredValue" => [
+              {"value" => "2000", "type" => "start"},
+              {"value" => "uuuu", "type" => "end"}
+            ],
+            "type" => "publication",
+            "encoding" => {"code" => "marc"},
+            "qualifier" => "questionable"
+          }
+        ]
+      end
+
+      it "extends the range to the current year" do
+        is_expected.to eq((2000..Date.today.year).to_a)
+      end
+    end
+
+    context "with an unknown start date" do
+      let(:dates) do
+        [
+          {
+            "structuredValue" => [
+              {"value" => "uuuu", "type" => "start"},
+              {"value" => "2000", "type" => "end"}
+            ],
+            "type" => "publication",
+            "encoding" => {"code" => "marc"},
+            "qualifier" => "questionable"
+          }
+        ]
+      end
+
+      it "uses only the known year" do
+        is_expected.to eq([2000])
+      end
+    end
   end
 
   describe "#imprint_str" do


### PR DESCRIPTION
@thatbudakguy does this change make sense for addressing cases where the start or end of an event is `uuuu` (unknown)? This fixes an issue I was having when indexing `pub_year_ints` for records like `gy844sy1998` and `dk904jd5864`:

```
     Failure/Error: d = d.change(month: 1, day: 1) if date&.precision == :year
     
     NoMethodError:
       undefined method 'precision' for an instance of EDTF::Unknown
```