### PR TITLE
Check for missing structuredValue value

### DIFF
--- a/lib/cocina_display/dates/date.rb
+++ b/lib/cocina_display/dates/date.rb
@@ -510,6 +510,11 @@ module CocinaDisplay
       attr_reader :date
 
       def self.normalize_to_edtf(value)
+        unless value
+          notifier&.notify("Invalid date value: #{value}")
+          return
+        end
+
         return "0000" if value.strip == "0"
 
         case value

--- a/spec/dates/date_range_spec.rb
+++ b/spec/dates/date_range_spec.rb
@@ -36,6 +36,22 @@ RSpec.describe CocinaDisplay::Dates::DateRange do
       end
     end
 
+    context "with a top-level edtf encoding and no values on the structured value entries" do
+      let(:cocina) do
+        {
+          "structuredValue" => [
+            {"type" => "start", "status" => "primary"},
+            {"type" => "end"}
+          ],
+          "encoding" => {"code" => "edtf"}
+        }
+      end
+
+      it "does not raise an error" do
+        expect { date_range }.not_to raise_error
+      end
+    end
+
     context "with a top-level type and no start/end types" do
       let(:cocina) do
         {


### PR DESCRIPTION
dor-services-app is starting to throw some indexing errors when a date's `structuredValue` lacks a `value`:

https://app.honeybadger.io/projects/50568/faults/127706880

You can see an example Cocina record here:

https://argo.stanford.edu/items/druid:xv845zv9436.json

DSA started to see these pop up because cocina_display now push the top-level date encoding down into the structured value, which causes EdtFormat.normalize_to_edtf to run in some situations where it didn't before.

Closes #285
