### PR TITLE
Identify ORCID ids by URI when a type is not present

### DIFF
--- a/lib/cocina_display/identifier.rb
+++ b/lib/cocina_display/identifier.rb
@@ -57,7 +57,7 @@ module CocinaDisplay
     # The type of the identifier, e.g. "DOI".
     # @return [String, nil]
     def type
-      ("DOI" if doi?) || cocina["type"].presence
+      ("DOI" if doi?) || ("ORCID" if orcid_uri?) || cocina["type"].presence
     end
 
     # The declared encoding of the identifier, if any.
@@ -96,6 +96,13 @@ module CocinaDisplay
     # @return [String, nil]
     def label_key
       type&.parameterize&.underscore
+    end
+
+    # Identifer is an ORCID if the URI contains "orcid.org".
+    # (in other cases this is indicated by type)
+    # @return [Boolean]
+    def orcid_uri?
+      cocina["uri"]&.include?("orcid.org")
     end
   end
 end

--- a/spec/contributor_spec.rb
+++ b/spec/contributor_spec.rb
@@ -600,5 +600,21 @@ RSpec.describe CocinaDisplay::Contributors::Contributor do
 
       it { is_expected.to eq([CocinaDisplay::Identifier.new({"type" => "ORCID", "id" => "0000-0002-1825-0097"})]) }
     end
+
+    context "with an ORCID identifier without a type" do
+      let(:cocina) do
+        {
+          "type" => "person",
+          "name" => [
+            {"value" => "John Doe"}
+          ],
+          "identifier" => [
+            {"uri" => "https://orcid.org/0000-0002-1825-0097"}
+          ]
+        }
+      end
+
+      it { is_expected.to eq([CocinaDisplay::Identifier.new({"uri" => "https://orcid.org/0000-0002-1825-0097"})]) }
+    end
   end
 end

--- a/spec/identifier_spec.rb
+++ b/spec/identifier_spec.rb
@@ -83,6 +83,36 @@ RSpec.describe CocinaDisplay::Identifier do
     it { is_expected.not_to be_doi }
   end
 
+  context "with an ORCID (without type)" do
+    let(:cocina) do
+      {
+        "uri" => "https://orcid.org/0000-0001-5028-5161"
+      }
+    end
+
+    it "has a uri" do
+      expect(subject.uri).to eq("https://orcid.org/0000-0001-5028-5161")
+    end
+
+    it "uses the uri for display" do
+      expect(subject.to_s).to eq("https://orcid.org/0000-0001-5028-5161")
+    end
+
+    it "parses the identifier from the uri" do
+      expect(subject.identifier).to eq("0000-0001-5028-5161")
+    end
+
+    it "has a type of ORCID" do
+      expect(subject.type).to eq("ORCID")
+    end
+
+    it "has a specific label" do
+      expect(subject.label).to eq("ORCID")
+    end
+
+    it { is_expected.not_to be_doi }
+  end
+
   context "with an ORCID (without URI)" do
     let(:cocina) do
       {


### PR DESCRIPTION
Part of [#1711](https://github.com/sul-dlss/purl/issues/1711)