### PR TITLE
Make Subjects and Forms have the same API

### DIFF
--- a/lib/cocina_display/forms/form.rb
+++ b/lib/cocina_display/forms/form.rb
@@ -5,7 +5,7 @@ module CocinaDisplay
   module Forms
     # A form associated with part or all of a Cocina object.
     class Form
-      attr_reader :cocina
+      attr_reader :cocina, :delimiter
 
       # Create a Form object from Cocina structured data.
       # Delegates to subclasses for specific types.
@@ -24,8 +24,10 @@ module CocinaDisplay
 
       # Create a Form object from Cocina structured data.
       # @param cocina [Hash]
-      def initialize(cocina)
+      # @param delimiter [String] The delimiter to use when flattening for display
+      def initialize(cocina, delimiter: " > ")
         @cocina = cocina
+        @delimiter = delimiter
       end
 
       # The value to use for display.
@@ -37,7 +39,7 @@ module CocinaDisplay
       # Single concatenated string value for the form.
       # @return [String]
       def flat_value
-        Utils.compact_and_join(values, delimiter: " > ")
+        Utils.compact_and_join(values, delimiter: delimiter)
       end
 
       # The raw values from the Cocina data, flattened if nested.

--- a/lib/cocina_display/subjects/subject.rb
+++ b/lib/cocina_display/subjects/subject.rb
@@ -2,12 +2,14 @@ module CocinaDisplay
   module Subjects
     # Base class for subjects in Cocina structured data.
     class Subject
-      attr_reader :cocina
+      attr_reader :cocina, :delimiter
 
       # Initialize a Subject object with Cocina structured data.
       # @param cocina [Hash] The Cocina structured data for the subject.
-      def initialize(cocina)
+      # @param delimiter [String] The delimiter to use when flattening for display
+      def initialize(cocina, delimiter: " > ")
         @cocina = cocina
+        @delimiter = delimiter
       end
 
       # The top-level type of the subject.
@@ -20,7 +22,7 @@ module CocinaDisplay
       # Array of display strings for each value in the subject.
       # Used for search, where each value should be indexed separately.
       # @return [Array<String>]
-      def display_values
+      def values
         subject_values.map(&:to_s).compact_blank
       end
 
@@ -28,13 +30,13 @@ module CocinaDisplay
       # Genre values are capitalized; other subject values are not.
       # @return [String]
       def to_s
-        (type == "genre") ? display_value&.upcase_first : display_value
+        (type == "genre") ? flat_value&.upcase_first : flat_value
       end
 
       # A string representation of the entire subject, concatenated for display.
       # @return [String]
-      def display_value
-        Utils.compact_and_join(display_values, delimiter: " > ")
+      def flat_value
+        Utils.compact_and_join(values, delimiter: delimiter)
       end
 
       # Label used to render the subject for display.


### PR DESCRIPTION
Both of these objects support querying for either their component
values or a flattened string value with delimiter – we just called
the methods different things in different places.

This makes the API the same, and also support storing and querying
an arbitrary delimiter.

Needed by SW to support linking the individual parts of a structured
Subject value.
