### PR TITLE
Map LC to searchworks resource types

### DIFF
--- a/lib/cocina_display/concerns/forms.rb
+++ b/lib/cocina_display/concerns/forms.rb
@@ -9,6 +9,7 @@ module CocinaDisplay
       def searchworks_resource_types
         mapped_values = resource_type_values.flat_map { |resource_type| searchworks_resource_type(resource_type) }
         mapped_values << "Dataset" if dataset?
+        mapped_values << "Software/Multimedia" if digital_only?
         mapped_values.uniq
       end
 
@@ -187,13 +188,21 @@ module CocinaDisplay
 
       private
 
-      # Map a resource type to SearchWorks format value(s).
+      # Is the object a digital resource without a more specific resource type?
+      # @return [Boolean]
+      def digital_only?
+        resource_type_values.all?("digital")
+      end
+
+      # Map a MODS or LC resource type to SearchWorks format value(s).
       # @param resource_type [String] The resource type to map.
       # @return [Array<String>]
       def searchworks_resource_type(resource_type)
         values = []
 
         case resource_type
+        when "dataset"
+          values << "Dataset"
         when "cartographic"
           values << "Map"
         when "manuscript", "mixed material"
@@ -202,10 +211,10 @@ module CocinaDisplay
           values << "Video/Film"
         when "notated music"
           values << "Music score"
-        when "software, multimedia"
+        when "software, multimedia", "multimedia"
           # Prevent GIS datasets from being labeled as "Software"
           values << "Software/Multimedia" unless cartographic? || dataset?
-        when "sound recording-musical", "sound recording-nonmusical", "sound recording"
+        when "sound recording-musical", "sound recording-nonmusical", "sound recording", "audio"
           values << "Sound recording"
         when "still image"
           values << "Image"
@@ -219,7 +228,7 @@ module CocinaDisplay
           else
             values << "Book"
           end
-        when "three dimensional object"
+        when "three dimensional object", "artifact", "tactile"
           values << "Object"
         end
 

--- a/spec/concerns/forms_spec.rb
+++ b/spec/concerns/forms_spec.rb
@@ -42,6 +42,48 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       end
     end
 
+    context "with LC resource types" do
+      let(:forms) do
+        [
+          {"value" => "Dataset", "type" => "resource type", "source" => {"value" => "LC resource types"}},
+          {"value" => "Digital", "type" => "resource type", "source" => {"value" => "LC resource types"}},
+          {"value" => "Multimedia", "type" => "resource type", "source" => {"value" => "LC resource types"}},
+          {"value" => "Audio", "type" => "resource type", "source" => {"value" => "LC resource types"}},
+          {"value" => "Artifact", "type" => "resource type", "source" => {"value" => "LC resource types"}},
+          {"value" => "Tactile", "type" => "resource type", "source" => {"value" => "LC resource types"}}
+        ]
+      end
+
+      it "maps and deduplicates the values" do
+        is_expected.to eq(["Dataset", "Software/Multimedia", "Sound recording", "Object"])
+      end
+
+      context "with a digital resource that is also a moving image" do
+        let(:forms) do
+          [
+            {"value" => "Digital", "type" => "resource type", "source" => {"value" => "LC resource types"}},
+            {"value" => "Moving image", "type" => "resource type", "source" => {"value" => "LC resource types"}}
+          ]
+        end
+
+        it "does not map to Software/Multimedia" do
+          is_expected.to eq(["Video/Film"])
+        end
+      end
+
+      context "with a digital resource that has no other resource types" do
+        let(:forms) do
+          [
+            {"value" => "Digital", "type" => "resource type", "source" => {"value" => "LC resource types"}}
+          ]
+        end
+
+        it "maps to Software/Multimedia" do
+          is_expected.to eq(["Software/Multimedia"])
+        end
+      end
+    end
+
     context "with a periodical" do
       let(:events) do
         [


### PR DESCRIPTION
Fixes #276 

The MODS and LC resource type terms are mostly the same. It made sense to me to add the unique LC terms to the existing mapping rather than creating a mostly duplicated mapping just for LC.