### PR TITLE
Automatically generate display labels for Identifiers

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,26 +26,20 @@ en:
         note: Note
         resource_type: Resource Type
       identifier:
-        doi: DOI
-        handle: Handle
         identifier: Identifier
+        local: Local identifier
+        other: Other identifier
+        doi: DOI
         isbn: ISBN
         ismn: ISMN
         isrc: ISRC
         issn: ISSN
         issn_l: ISSN
-        issue_number: Issue number
-        language: Language
         lccn: LCCN
-        matrix_number: Matrix number
-        music_plate: Music plate
-        music_publisher: Music publisher
         oclc: OCLC
         orcid: ORCID
         sici: SICI
-        stock_number: Stock number
         upc: UPC
-        videorecording_identifier: Videorecording identifier
       language: Language
       license: License
       note:

--- a/lib/cocina_display/identifier.rb
+++ b/lib/cocina_display/identifier.rb
@@ -80,7 +80,7 @@ module CocinaDisplay
     # @return [String]
     def label
       cocina["displayLabel"].presence ||
-        I18n.t(label_key, default: :identifier, scope: "cocina_display.field_label.identifier")
+        I18n.t(label_key, default: default_label, scope: "cocina_display.field_label.identifier")
     end
 
     # Check if the identifier is a DOI.
@@ -91,6 +91,12 @@ module CocinaDisplay
     end
 
     private
+
+    # Default label for an identifier, based on its type.
+    # @return [String]
+    def default_label
+      type&.capitalize || :identifier
+    end
 
     # Key used for i18n lookup of the label, based on the type.
     # @return [String, nil]

--- a/spec/concerns/identifiers_spec.rb
+++ b/spec/concerns/identifiers_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         {
           "DOI" => ["https://doi.org/10.25740/ppax-bf07", "https://doi.org/10.25740/sb4q-wj06", "https://doi.org/identification-doi"],
           "ISBN" => ["978-0-061-96436-7"],
-          "Identifier" => ["other-id-123", "other-id-456"],
+          "Other identifier" => ["other-id-123", "other-id-456"],
           "Custom label" => ["custom-id-123"]
         }
       )

--- a/spec/identifier_spec.rb
+++ b/spec/identifier_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe CocinaDisplay::Identifier do
       expect(subject.uri).to be_nil
     end
 
-    it "has a generic label" do
-      expect(subject.label).to eq("Identifier")
+    it "has a label" do
+      expect(subject.label).to eq("Local identifier")
     end
 
     it { is_expected.not_to be_doi }


### PR DESCRIPTION
Rather than enumerating each type with a corresponding label, this
lets us infer a label using the type.

Fixes https://github.com/sul-dlss/cocina_display/issues/298
