### PR TITLE
Fix removal of delimiters inside notes

### DIFF
--- a/lib/cocina_display/note.rb
+++ b/lib/cocina_display/note.rb
@@ -35,7 +35,7 @@ module CocinaDisplay
     # @return [Array<String>]
     def values
       Utils.flatten_nested_values(cocina).pluck("value")
-        .map { |value| value.gsub(delimiter.strip, "").strip }
+        .map { |value| cleaned_value(value) }
         .compact_blank
     end
 
@@ -45,7 +45,7 @@ module CocinaDisplay
       Utils.flatten_nested_values(cocina).each_with_object({}) do |node, hash|
         type = node["type"]
         hash[type] ||= []
-        hash[type] << node["value"]
+        hash[type] << cleaned_value(node["value"])
       end
     end
 
@@ -109,6 +109,15 @@ module CocinaDisplay
 
     def default_label
       type&.capitalize || I18n.t("cocina_display.field_label.note.note")
+    end
+
+    # Remove the delimiter from the ends of the value and strip whitespace.
+    # @param value [String]
+    # @return [String]
+    def cleaned_value(value)
+      value.gsub(/\s*#{Regexp.escape(delimiter.strip)}\s*$/, " ")
+        .gsub(/^\s*#{Regexp.escape(delimiter.strip)}\s*/, " ")
+        .strip
     end
   end
 end

--- a/spec/note_spec.rb
+++ b/spec/note_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe CocinaDisplay::Note do
         expect(subject.to_s).to eq "A note about a thing. -- Another note about a thing."
       end
     end
+
+    context "with a value that has a delimiter inside it, but not at the end" do
+      let(:note) do
+        {"value" => "A note about a thing. -- With a delimiter."}
+      end
+
+      it "leaves the delimiter alone" do
+        expect(subject.to_s).to eq "A note about a thing. -- With a delimiter."
+      end
+    end
   end
 
   describe "#type" do


### PR DESCRIPTION
Purl integration tests revealed a case where an object (gx074xz5520)
had a preferred citation note that included our note delimiter "--".

Because we stripped it everywhere, instead of just at the ends, this
resulted in a strange-looking value with words smashed together.

This fixes the behavior introduced in ae54151febae6b2e10b5f030ffb2c5febb679467
so that it only affects the start and end of values.
