### PR TITLE
Ensure delimiter behavior only impacts TOC notes

### DIFF
--- a/lib/cocina_display/note.rb
+++ b/lib/cocina_display/note.rb
@@ -8,14 +8,12 @@ module CocinaDisplay
     TOC_TYPES = ["table of contents"].freeze
     TOC_DISPLAY_LABEL_REGEX = /Table of contents/i
 
-    attr_reader :cocina, :delimiter
+    attr_reader :cocina
 
     # Initialize a Note from Cocina structured data.
     # @param cocina [Hash]
-    # @param delimiter [String] Delimiter to use when joining for display.
-    def initialize(cocina, delimiter: " -- ")
+    def initialize(cocina)
       @cocina = cocina
-      @delimiter = delimiter
     end
 
     # The value to use for display.
@@ -24,28 +22,47 @@ module CocinaDisplay
       flat_value
     end
 
+    # Delimiter used to join multiple values for display.
+    # @return [String, nil]
+    def delimiter
+      " -- " if table_of_contents?
+    end
+
+    # Does this note use a delimiter?
+    # @return [Boolean]
+    def delimited?
+      delimiter.present?
+    end
+
     # Single concatenated string value for the note.
     # @return [String, nil]
     def flat_value
-      Utils.compact_and_join(values, delimiter: delimiter).presence
+      Utils.compact_and_join(values, delimiter: delimiter || "").presence
     end
 
     # The raw values from the Cocina data, flattened if nested.
     # Strips excess whitespace and the delimiter if present.
+    # Splits on the delimiter if it was already included in the values(s).
     # @return [Array<String>]
     def values
       Utils.flatten_nested_values(cocina).pluck("value")
         .map { |value| cleaned_value(value) }
+        .flat_map { |value| delimited? ? value.split(delimiter.strip) : [value] }
         .compact_blank
     end
 
     # The raw values from the Cocina data as a hash with type as key.
-    # @return [Hash{String => String}]
+    # Strips excess whitespace and the delimiter if present.
+    # Splits on the delimiter if it was already included in the values(s).
+    # @return [Hash{String => Array<String>}]
     def values_by_type
       Utils.flatten_nested_values(cocina).each_with_object({}) do |node, hash|
-        type = node["type"]
-        hash[type] ||= []
-        hash[type] << cleaned_value(node["value"])
+        value = cleaned_value(node["value"])
+        (delimited? ? value.split(delimiter.strip) : [value]).each do |part|
+          type = node["type"]
+          hash[type] ||= []
+          hash[type] << part
+        end
       end
     end
 
@@ -115,6 +132,8 @@ module CocinaDisplay
     # @param value [String]
     # @return [String]
     def cleaned_value(value)
+      return value.strip unless delimited?
+
       value.gsub(/\s*#{Regexp.escape(delimiter.strip)}\s*$/, " ")
         .gsub(/^\s*#{Regexp.escape(delimiter.strip)}\s*/, " ")
         .strip

--- a/spec/note_spec.rb
+++ b/spec/note_spec.rb
@@ -30,7 +30,17 @@ RSpec.describe CocinaDisplay::Note do
       end
 
       it "returns the concatenated values" do
-        expect(subject.to_s).to eq "A note about a thing. -- Another note about a thing."
+        expect(subject.to_s).to eq "A note about a thing. Another note about a thing."
+      end
+    end
+
+    context "with a structuredValue when the note is a table of contents" do
+      let(:note) do
+        {"structuredValue" => [{"value" => "pt.1. A note about a thing."}, {"value" => "pt.2. Another note about a thing."}], "type" => "table of contents"}
+      end
+
+      it "returns the concatenated values with delimiter" do
+        expect(subject.to_s).to eq "pt.1. A note about a thing. -- pt.2. Another note about a thing."
       end
     end
 
@@ -255,6 +265,20 @@ RSpec.describe CocinaDisplay::Note do
   end
 
   describe "#values" do
+    context "with a non-TOC note" do
+      # from druid:gx074xz5520
+      let(:note) do
+        {
+          "value" => "Stanford University. Cabinet, Stanford University--Administration.",
+          "type" => "preferred citation"
+        }
+      end
+
+      it "leaves the values unchanged" do
+        expect(subject.values).to eq ["Stanford University. Cabinet, Stanford University--Administration."]
+      end
+    end
+
     context "with a TOC with delimiters in the values" do
       # from druid:bm971cx9348
       let(:note) do
@@ -272,9 +296,53 @@ RSpec.describe CocinaDisplay::Note do
         expect(subject.values).to eq ["pt.2. Abergavenny", "pt.5. Merthyr Tydfil"]
       end
     end
+
+    context "with a TOC with delimiters in a single value" do
+      # from druid:sw284bk0647
+      let(:note) do
+        {
+          "type" => "table of contents",
+          # rubocop:disable Layout/LineLength
+          "value" => "Progress: its law and cause.--Manners and fashion.--The genesis of science.--The physiology of laughter.--The origin and function of music.--The nebular hypothesis.--Bain on the emotions and the will.--Illogical geology.--The development hypothesis.--The social organism.--Use and beauty.--The sources of architectural types.--The use of anthropomorphism."
+          # rubocop:enable Layout/LineLength
+        }
+      end
+
+      it "returns the values split on the delimiter" do
+        expect(subject.values).to eq [
+          "Progress: its law and cause.",
+          "Manners and fashion.",
+          "The genesis of science.",
+          "The physiology of laughter.",
+          "The origin and function of music.",
+          "The nebular hypothesis.",
+          "Bain on the emotions and the will.",
+          "Illogical geology.",
+          "The development hypothesis.",
+          "The social organism.",
+          "Use and beauty.",
+          "The sources of architectural types.",
+          "The use of anthropomorphism."
+        ]
+      end
+    end
   end
 
   describe "#flat_value" do
+    context "with a non-TOC note" do
+      # from druid:gx074xz5520
+      let(:note) do
+        {
+          "value" => "Stanford University. Cabinet, Stanford University--Administration.",
+          "type" => "preferred citation"
+        }
+      end
+
+      it "leaves the value unchanged" do
+        expect(subject.flat_value).to eq "Stanford University. Cabinet, Stanford University--Administration."
+      end
+    end
+
     context "with a TOC with delimiters in the values" do
       # from druid:bm971cx9348
       let(:note) do
@@ -290,6 +358,24 @@ RSpec.describe CocinaDisplay::Note do
 
       it "returns the values joined with delimiter" do
         expect(subject.flat_value).to eq "pt.2. Abergavenny -- pt.5. Merthyr Tydfil"
+      end
+    end
+
+    context "with a TOC with delimiters in a single value" do
+      # from druid:sw284bk0647
+      let(:note) do
+        {
+          "type" => "table of contents",
+          # rubocop:disable Layout/LineLength
+          "value" => "Progress: its law and cause.--Manners and fashion.--The genesis of science.--The physiology of laughter.--The origin and function of music.--The nebular hypothesis.--Bain on the emotions and the will.--Illogical geology.--The development hypothesis.--The social organism.--Use and beauty.--The sources of architectural types.--The use of anthropomorphism."
+          # rubocop:enable Layout/LineLength
+        }
+      end
+
+      it "re-joins using the delimiter" do
+        # rubocop:disable Layout/LineLength
+        expect(subject.flat_value).to eq "Progress: its law and cause. -- Manners and fashion. -- The genesis of science. -- The physiology of laughter. -- The origin and function of music. -- The nebular hypothesis. -- Bain on the emotions and the will. -- Illogical geology. -- The development hypothesis. -- The social organism. -- Use and beauty. -- The sources of architectural types. -- The use of anthropomorphism."
+        # rubocop:enable Layout/LineLength
       end
     end
   end


### PR DESCRIPTION
The special logic for splitting/joining using a delimiter should
only apply to notes with type "table of contents".
