### PR TITLE
Add additional labels for event note types

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
           default: Imprint note
           edition: Edition
           issuance: Issuance
+          frequency: Frequency
+          copyright_statement: Copyright statement
       form:
         digital_origin: Digital origin
         extent: Extent


### PR DESCRIPTION
This fixes an issue where zf208gz2565 when rendered from mods
shows its two event notes as "Issuance" and "Frequency", but the
latter is shown only as "Imprint note" when rendering from
Cocina because it wasn't a recognized label.

Also adds an entry for the last remaining known event note type,
copyright statement.
