### PR TITLE
Add a separate pub_date_str method to contrast with pub_year_str

### DIFF
--- a/lib/cocina_display/concerns/events.rb
+++ b/lib/cocina_display/concerns/events.rb
@@ -56,9 +56,13 @@ module CocinaDisplay
       #   "1932 - 2012"
       # @example BCE year range, [ca. 3500 BCE] - 3101 BCE (yv690gn5376)
       #   "3500 BCE - 3101 BCE"
+      # @example Unencoded string, 'about 933'
+      #   "933 CE"
+      # @example Not parsable, 'invalid-date'
+      #   nil
       def pub_year_str(ignore_qualified: false)
         date = pub_date(ignore_qualified: ignore_qualified)
-        return unless date
+        return unless date&.parsed_date?
 
         date.decoded_value(allowed_precisions: [:year, :decade, :century])
       end
@@ -77,6 +81,23 @@ module CocinaDisplay
       #   "-564990000-568980000"
       def pub_date_sort_str(ignore_qualified: false)
         pub_date(ignore_qualified: ignore_qualified)&.sort_key
+      end
+
+      # String for displaying the publication date.
+      # Considers publication, creation, and capture dates in that order.
+      # Prefers dates marked as primary and those with a declared encoding.
+      # If not encoded, returns the original string value from the Cocina.
+      # @return [String, nil]
+      # @example w3cdtf encoded year with month and day (vc109xd3118)
+      #   "August 21, 2024"
+      # @example w3cdtf encoded approximate year range (bb099mt5053)
+      #   "[ca. 1932 - 2012]"
+      # @example Unencoded string, 'about 933'
+      #   "about 933"
+      # @example Not parsable, 'invalid-date'
+      #   "invalid-date"
+      def pub_date_str
+        pub_date&.to_s
       end
 
       # String for displaying the imprint statement(s).

--- a/lib/cocina_display/dates/date.rb
+++ b/lib/cocina_display/dates/date.rb
@@ -125,9 +125,14 @@ module CocinaDisplay
       end
 
       # The string representation of the date for display.
+      # Uses the raw value if the date was not encoded or couldn't be parsed.
       # @return [String]
       def to_s
-        qualified_value
+        if !parsed_date? || (!encoding? && value !~ /^-?\d+$/ && value !~ /^[\dXxu?-]{4}$/)
+          value.strip
+        else
+          qualified_value
+        end
       end
 
       # Label used to group the date for display.
@@ -304,9 +309,6 @@ module CocinaDisplay
       #   Defaults to [:day, :month, :year, :decade, :century, :unknown].
       # @return [String]
       def decoded_value(allowed_precisions: [:day, :month, :year, :decade, :century, :unknown])
-        if !parsed_date? || (!encoding? && value !~ /^-?\d+$/ && value !~ /^[\dXxu?-]{4}$/)
-          return value.strip
-        end
         if date.is_a?(EDTF::Interval)
           range = [
             Date.format_date(date.min, date.min.precision, allowed_precisions),

--- a/lib/cocina_display/dates/date_range.rb
+++ b/lib/cocina_display/dates/date_range.rb
@@ -40,11 +40,11 @@ module CocinaDisplay
         @type = cocina["type"]
       end
 
-      # The values of the start and stop dates as an array.
+      # The joined values of the start and stop dates.
       # @see CocinaDisplay::Date#value
-      # @return [Array<String>]
+      # @return [String]
       def value
-        [start&.value, stop&.value].compact
+        [start&.value, stop&.value].compact.uniq.join(" - ").strip
       end
 
       # Key used to sort this date range. Respects BCE/CE ordering and precision.

--- a/spec/concerns/events_spec.rb
+++ b/spec/concerns/events_spec.rb
@@ -178,6 +178,86 @@ RSpec.describe CocinaDisplay::CocinaRecord do
 
       it { is_expected.to eq("2020 - 2021") }
     end
+
+    context "with a date value embedded in running text" do
+      let(:dates) do
+        [
+          {"value" => "view of approximately 1848, published about 1865", "type" => "publication"}
+        ]
+      end
+
+      it { is_expected.to eq("1848") }
+    end
+
+    context "with an unparsable date" do
+      let(:dates) do
+        [
+          {"value" => "not a date", "type" => "publication"}
+        ]
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#pub_date_str" do
+    subject { record.pub_date_str }
+
+    context "with a year" do
+      let(:dates) do
+        [
+          {"value" => "2020", "type" => "publication"}
+        ]
+      end
+
+      it { is_expected.to eq("2020") }
+    end
+
+    context "with a decade date (209x)" do
+      let(:dates) do
+        [
+          {"value" => "209x", "type" => "publication", "encoding" => {"code" => "edtf"}}
+        ]
+      end
+
+      it { is_expected.to eq("2090s") }
+    end
+
+    context "with an encoded date range (2020-01-01 to 2021-10-31)" do
+      let(:dates) do
+        [
+          {
+            "structuredValue" => [
+              {"value" => "2020-01-01", "type" => "start", "encoding" => {"code" => "w3cdtf"}},
+              {"value" => "2021-10-31", "type" => "end", "encoding" => {"code" => "w3cdtf"}}
+            ],
+            "type" => "publication"
+          }
+        ]
+      end
+
+      it { is_expected.to eq("January 1, 2020 - October 31, 2021") }
+    end
+
+    context "with a date value embedded in running text" do
+      let(:dates) do
+        [
+          {"value" => "view of approximately 1848, published about 1865", "type" => "publication"}
+        ]
+      end
+
+      it { is_expected.to eq("view of approximately 1848, published about 1865") }
+    end
+
+    context "with an unparsable date" do
+      let(:dates) do
+        [
+          {"value" => "not a date", "type" => "publication"}
+        ]
+      end
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe "#pub_year_int" do

--- a/spec/dates/date_range_spec.rb
+++ b/spec/dates/date_range_spec.rb
@@ -79,13 +79,13 @@ RSpec.describe CocinaDisplay::Dates::DateRange do
 
     it "sorts dates correctly" do
       sorted_dates = dates.sort
-      expect(sorted_dates.map(&:value)).to eq([
-        ["0455", "0496"],
-        ["1902", "2045"],
-        ["2022-10-30", "unparseable"],
-        ["2022-10-30", "2023-01-01"],
-        ["2023", "2023-01-01"],
-        ["2023-01-01", "2023-01-02"]
+      expect(sorted_dates.map(&:to_s)).to eq([
+        "455 CE - 496 CE",
+        "1902 - 2045",
+        "October 30, 2022 - Unknown",
+        "October 30, 2022 - January 1, 2023",
+        "2023 - January 1, 2023",
+        "January 1, 2023 - January 2, 2023"
       ])
     end
   end

--- a/spec/dates/date_spec.rb
+++ b/spec/dates/date_spec.rb
@@ -429,16 +429,16 @@ RSpec.describe CocinaDisplay::Dates::Date do
     context "with an unparsable date" do
       let(:cocina) { {"value" => "invalid-date", "encoding" => {"code" => "edtf"}} }
 
-      it "returns the value unmodified" do
-        expect(date.decoded_value).to eq("invalid-date")
+      it "shows as Unknown" do
+        expect(date.decoded_value).to eq("Unknown")
       end
     end
 
-    context "with an unencoded date" do
+    context "with an unencoded but parsable date" do
       let(:cocina) { {"value" => "about 933"} }
 
-      it "returns the value unmodified" do
-        expect(date.decoded_value).to eq("about 933")
+      it "uses the parsed value" do
+        expect(date.decoded_value).to eq("933 CE")
       end
     end
 


### PR DESCRIPTION
This adds a distinct method for retrieving publication date info
in a way that respects the original record, and clarifies the
differences between it and pub_year_str, which now tries harder
to return something that is an actual year.

These two methods correspond to different destinations in Searchworks's
indexer, so this helps with parity with MARC.
