### PR TITLE
Fix extra padding in open-ended range rendering

### DIFF
--- a/lib/cocina_display/dates/date_range.rb
+++ b/lib/cocina_display/dates/date_range.rb
@@ -133,7 +133,7 @@ module CocinaDisplay
             "[#{decoded_value}]"
           end
         else
-          "#{start&.qualified_value} - #{stop&.qualified_value}"
+          [start&.qualified_value, stop&.qualified_value].uniq.join(" - ").strip
         end
       end
 

--- a/spec/concerns/events_spec.rb
+++ b/spec/concerns/events_spec.rb
@@ -239,6 +239,21 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       it { is_expected.to eq("January 1, 2020 - October 31, 2021") }
     end
 
+    context "with an open-ended range" do
+      let(:dates) do
+        [
+          {
+            "structuredValue" => [
+              {"value" => "2000", "type" => "start"}
+            ],
+            "type" => "publication"
+          }
+        ]
+      end
+
+      it { is_expected.to eq("2000 -") }
+    end
+
     context "with a date value embedded in running text" do
       let(:dates) do
         [


### PR DESCRIPTION
This ensures that open-ended date ranges display like "2000 -"
instead of including an extra space ("2000 - ").

Without this, #pub_year_str and #pub_date_str produce differing
output for records like bm971cx9348 that include an open-ended
range.

No space after the hyphen is preferred, per Arcadia.
