### PR TITLE
Distinguish Event#to_s from Imprint#to_s; adjust Imprint heuristic

### DIFF
--- a/lib/cocina_display/concerns/events.rb
+++ b/lib/cocina_display/concerns/events.rb
@@ -126,7 +126,10 @@ module CocinaDisplay
       # All root level events associated with the object.
       # @return [Array<CocinaDisplay::Events::Event>]
       def events
-        @events ||= path("$.description.event.*").map { |event| CocinaDisplay::Events::Event.new(event) }
+        @events ||= path("$.description.event.*").map do |cocina|
+          event = CocinaDisplay::Events::Event.new(cocina)
+          event.imprint? ? CocinaDisplay::Events::Imprint.new(cocina) : event
+        end
       end
 
       # The adminMetadata creation event (When was it was deposited?)
@@ -144,12 +147,9 @@ module CocinaDisplay
       end
 
       # Array of CocinaDisplay::Imprint objects for all relevant Cocina events.
-      # Considers publication, creation, capture, and copyright events.
-      # Considers event types as well as date types if the event is untyped.
-      # Prefers events where the date was not encoded, if any.
-      # @return [Array<CocinaDisplay::Imprint>] The list of Imprint objects
+      # @return [Array<CocinaDisplay::Imprint>]
       def imprint_events
-        events.filter(&:imprint?)
+        events.filter { |event| event.is_a? CocinaDisplay::Events::Imprint }
       end
 
       # All dates associated with the object via an event.

--- a/lib/cocina_display/events/event.rb
+++ b/lib/cocina_display/events/event.rb
@@ -16,7 +16,7 @@ module CocinaDisplay
       # @note Also supports `event1.between?(event2, event3)` via {Comparable}.
       # @return [Integer, nil]
       def <=>(other)
-        [unique_dates_for_display] <=> [other.unique_dates_for_display] if other.is_a?(Event)
+        [dates] <=> [other.dates] if other.is_a?(Event)
       end
 
       # The display label for the event.
@@ -26,7 +26,6 @@ module CocinaDisplay
       # @return [String]
       def label
         return cocina["displayLabel"] if cocina["displayLabel"].present?
-        return "Imprint" if imprint?
         return dates.map(&:label).first if date_only?
 
         type&.capitalize || date_types.first&.capitalize || "Event"
@@ -80,7 +79,10 @@ module CocinaDisplay
       # @note Unencoded dates or no dates often indicate an imprint statement.
       # @return [Boolean]
       def imprint?
-        (has_type?("publication") || types.empty?) && (dates.none?(&:encoding?) || dates.none?)
+        contributors.present? &&
+          locations.present? &&
+          (has_type?("publication") || types.empty?) &&
+          (dates.any? { |date| !date.encoding? } || dates.none?)
       end
 
       # All contributors associated with this event.
@@ -107,49 +109,11 @@ module CocinaDisplay
         end
       end
 
-      # String representation of the event using edition, dates, locations, and contributors.
-      # Format is inspired by typical imprint statements for books.
+      # String representation of the event using date and location.
       # @return [String]
-      # @example "2nd ed. - New York : John Doe, 1999"
+      # @example "John Doe, New York (State), 1999"
       def to_s
-        place_contrib = Utils.compact_and_join([place_str, contributor_str], delimiter: " : ")
-        note_place_contrib = Utils.compact_and_join([edition_note_str, place_contrib], delimiter: " - ")
-        Utils.compact_and_join([note_place_contrib, date_str, copyright_note_str], delimiter: ", ")
-      end
-
-      # Filter dates for uniqueness using base value according to predefined rules.
-      # 1. For a group of dates with the same base value, choose a single one
-      # 2. Prefer unencoded dates over encoded ones when choosing a single date
-      # 3. Remove date ranges that duplicate any unencoded non-range dates
-      # @return [Array<CocinaDisplay::Dates::Date>]
-      # @see CocinaDisplay::Dates::Date#base_value
-      # @see https://consul.stanford.edu/display/chimera/MODS+display+rules#MODSdisplayrules-3b.%3CoriginInfo%3E
-      def unique_dates_for_display
-        # Choose a single date for each group with the same base value
-        deduped_dates = dates.group_by(&:base_value).map do |base_value, group|
-          if (unencoded = group.reject(&:encoding?)).any?
-            unencoded.first
-          else
-            group.first
-          end
-        end
-
-        # Remove any ranges that duplicate part of an unencoded non-range date
-        ranges, singles = deduped_dates.partition { |date| date.is_a?(CocinaDisplay::Dates::DateRange) }
-        unencoded_singles_dates = singles.reject(&:encoding?).flat_map(&:to_a)
-        ranges.reject! { |date_range| unencoded_singles_dates.any? { |date| date_range.as_range.include?(date) } }
-
-        (singles + ranges).sort
-      end
-
-      # Filter locations to display according to predefined rules.
-      # 1. Prefer unencoded locations (plain value) over encoded ones
-      # 2. If no unencoded locations but there are MARC country codes, decode them
-      # 3. Keep only unique locations after decoding
-      def locations_for_display
-        unencoded_locs, encoded_locs = locations.partition { |loc| loc.unencoded_value? }
-        locs_for_display = unencoded_locs.presence || encoded_locs
-        locs_for_display.map(&:to_s).compact_blank.uniq
+        Utils.compact_and_join([place_str, date_str], delimiter: ", ")
       end
 
       # Union of event's type and its date types.
@@ -168,34 +132,38 @@ module CocinaDisplay
         to_s == date_str
       end
 
-      # The date portion of the imprint statement, comprising all unique dates.
+      # The dates associated with this event that should be used for display.
+      # Prefers encoded dates when there are duplicates.
+      # @return [Array<CocinaDisplay::Dates::Date>]
+      def display_dates
+        # Choose a single date for each group with the same base value;
+        # prefer encoded dates when there are duplicates.
+        deduped_dates = dates.group_by(&:base_value).map do |base_value, group|
+          if (encoded = group.filter(&:encoding?)).any?
+            encoded.first
+          else
+            group.first
+          end
+        end
+
+        # Remove any ranges that duplicate part of an encoded non-range date
+        ranges, singles = deduped_dates.partition { |date| date.is_a?(CocinaDisplay::Dates::DateRange) }
+        encoded_singles_dates = singles.filter(&:encoding?).flat_map(&:to_a)
+        ranges.reject! { |date_range| encoded_singles_dates.any? { |date| date_range.as_range.include?(date) } }
+
+        (singles + ranges).sort
+      end
+
+      # Dates associated with this event as a single string.
       # @return [String]
       def date_str
-        Utils.compact_and_join(unique_dates_for_display.map(&:to_s), delimiter: "; ")
+        display_dates.map(&:qualified_value).compact_blank.uniq.to_sentence
       end
 
-      # Edition notes associated with the event as a single string.
-      # @return [String]
-      def edition_note_str
-        Utils.compact_and_join(notes.filter { |note| note.type == "edition" }.map(&:to_s), delimiter: ", ")
-      end
-
-      # Copyright notes associated with the event as a single string.
-      # @return [String]
-      def copyright_note_str
-        Utils.compact_and_join(notes.filter { |note| note.type == "copyright statement" }.map(&:to_s), delimiter: ", ")
-      end
-
-      # All contributors associated with the event as a single string.
-      # @return [String]
-      def contributor_str
-        Utils.compact_and_join(contributors.map(&:display_name), delimiter: " : ")
-      end
-
-      # The place of publication, combining all location values.
+      # Locations associated with this event as a single string.
       # @return [String]
       def place_str
-        Utils.compact_and_join(locations_for_display, delimiter: " : ")
+        locations.map(&:to_s).compact_blank.uniq.join(", ")
       end
     end
   end

--- a/lib/cocina_display/events/imprint.rb
+++ b/lib/cocina_display/events/imprint.rb
@@ -1,0 +1,89 @@
+module CocinaDisplay
+  module Events
+    # An imprint statement associated with an object.
+    class Imprint < Event
+      # Imprints are labelled "Imprint" unless overridden by a displayLabel.
+      # @return [String]
+      def label
+        cocina["displayLabel"].presence || "Imprint"
+      end
+
+      # Imprint statement for a book, formatted using typical conventions.
+      # @return [String]
+      # @example "2nd ed. - New York : John Doe, 1999"
+      def to_s
+        place_contrib = Utils.compact_and_join([place_str, contributor_str], delimiter: " : ")
+        note_place_contrib = Utils.compact_and_join([edition_note_str, place_contrib], delimiter: " - ")
+        Utils.compact_and_join([note_place_contrib, date_str, copyright_note_str], delimiter: ", ")
+      end
+
+      private
+
+      # Filter dates for uniqueness using base value according to predefined rules.
+      # 1. For a group of dates with the same base value, choose a single one
+      # 2. Prefer unencoded dates over encoded ones when choosing a single date
+      # 3. Remove date ranges that duplicate any unencoded non-range dates
+      # @return [Array<CocinaDisplay::Dates::Date>]
+      # @see CocinaDisplay::Dates::Date#base_value
+      # @see https://consul.stanford.edu/display/chimera/MODS+display+rules#MODSdisplayrules-3b.%3CoriginInfo%3E
+      def display_dates
+        # Choose a single date for each group with the same base value
+        deduped_dates = dates.group_by(&:base_value).map do |base_value, group|
+          if (unencoded = group.reject(&:encoding?)).any?
+            unencoded.first
+          else
+            group.first
+          end
+        end
+
+        # Remove any ranges that duplicate part of an unencoded non-range date
+        ranges, singles = deduped_dates.partition { |date| date.is_a?(CocinaDisplay::Dates::DateRange) }
+        unencoded_singles_dates = singles.reject(&:encoding?).flat_map(&:to_a)
+        ranges.reject! { |date_range| unencoded_singles_dates.any? { |date| date_range.as_range.include?(date) } }
+
+        (singles + ranges).sort
+      end
+
+      # Filter locations to display according to predefined rules.
+      # 1. Prefer unencoded locations (plain value) over encoded ones
+      # 2. If no unencoded locations but there are MARC country codes, decode them
+      # 3. Keep only unique locations after decoding
+      # @return [Array<String>]
+      def display_locations
+        unencoded_locs, encoded_locs = locations.partition { |loc| loc.unencoded_value? }
+        locs_for_display = unencoded_locs.presence || encoded_locs
+        locs_for_display.map(&:to_s).compact_blank.uniq
+      end
+
+      # Dates associated with this event as a single string.
+      # @return [String]
+      def date_str
+        Utils.compact_and_join(display_dates.map(&:to_s), delimiter: "; ")
+      end
+
+      # Edition notes associated with the event as a single string.
+      # @return [String]
+      def edition_note_str
+        Utils.compact_and_join(notes.filter { |note| note.type == "edition" }.map(&:to_s), delimiter: ", ")
+      end
+
+      # Copyright notes associated with the event as a single string.
+      # @return [String]
+      def copyright_note_str
+        Utils.compact_and_join(notes.filter { |note| note.type == "copyright statement" }.map(&:to_s), delimiter: ", ")
+      end
+
+      # All contributors associated with the event as a single string.
+      # @return [String]
+      def contributor_str
+        Utils.compact_and_join(contributors.map(&:display_name), delimiter: " : ")
+      end
+
+      # The place of publication, combining all location values.
+      # @return [String]
+      def place_str
+        Utils.compact_and_join(display_locations, delimiter: " : ")
+      end
+    end
+  end
+end

--- a/spec/concerns/events_spec.rb
+++ b/spec/concerns/events_spec.rb
@@ -877,53 +877,57 @@ RSpec.describe CocinaDisplay::CocinaRecord do
   end
 
   describe "#event_display_data" do
+    let(:cocina) do
+      {
+        "description" => {
+          "event" => events
+        }
+      }
+    end
+
     subject { CocinaDisplay::DisplayData.to_hash(record.event_display_data) }
 
     context "with events that only have dates" do
-      let(:cocina) do
-        {
-          "description" => {
-            "event" => [
+      let(:events) do
+        [
+          {
+            "date" => [
               {
-                "date" => [
+                "structuredValue" => [
                   {
-                    "structuredValue" => [
-                      {
-                        "value" => "1758",
-                        "type" => "start"
-                      },
-                      {
-                        "value" => "uuuu",
-                        "type" => "end"
-                      }
-                    ],
-                    "type" => "publication",
-                    "encoding" => {
-                      "code" => "marc"
-                    },
-                    "qualifier" => "questionable"
+                    "value" => "1758",
+                    "type" => "start"
+                  },
+                  {
+                    "value" => "uuuu",
+                    "type" => "end"
                   }
-                ]
-              },
-              {
-                "date" => [{"value" => "invalid-date", "type" => "production"}] # left alone
-              },
-              {
-                "date" => [{"type" => "copyright", "value" => "-0099", "encoding" => {"code" => "edtf"}}]
-              },
-              {
-                "date" => [{"value" => "199x", "encoding" => {"code" => "edtf"}, "displayLabel" => "Fictional date"}]
+                ],
+                "type" => "publication",
+                "encoding" => {
+                  "code" => "marc"
+                },
+                "qualifier" => "questionable"
               }
             ]
+          },
+          {
+            "date" => [{"value" => "invalid-date", "type" => "production"}] # left alone
+          },
+          {
+            "date" => [{"type" => "copyright", "value" => "-0099", "encoding" => {"code" => "edtf"}}]
+          },
+          {
+            "date" => [{"value" => "199x", "encoding" => {"code" => "edtf"}, "displayLabel" => "Fictional date"}]
           }
-        }
+        ]
       end
 
       it "uses date labels and display labels to group content" do
         expect(subject).to eq(
           {
             "Publication date" => ["[1758 - Unknown?]"],
-            "Production date" => ["invalid-date"],
+            "Production date" => ["Unknown"],
             "Copyright date" => ["100 BCE"],
             "Fictional date" => ["1990s"]
           }
@@ -931,76 +935,92 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       end
     end
 
+    context "with an unencoded date-only event" do
+      let(:events) do
+        [
+          {
+            "date" => [
+              {"value" => "2020", "type" => "publication"}
+            ]
+          }
+        ]
+      end
+
+      it "treats the event as a publication date, not imprint" do
+        expect(subject).to eq(
+          {
+            "Publication date" => ["2020"]
+          }
+        )
+      end
+    end
+
     context "with events that include notes" do
       # from druid:zf208gz2565
-      let(:cocina) do
-        {
-          "description" => {
-            "event" => [
+      let(:events) do
+        [
+          {
+            "date" => [
               {
-                "date" => [
-                  {
-                    "value" => "1866-02-22",
-                    "type" => "publication",
-                    "status" => "primary",
-                    "encoding" => {
-                      "code" => "w3cdtf"
-                    }
-                  }
-                ],
-                "location" => [
-                  {
-                    "code" => "nyu",
-                    "source" => {
-                      "code" => "marccountry"
-                    }
-                  }
-                ],
-                "note" => [
-                  {
-                    "value" => "serial",
-                    "type" => "issuance",
-                    "source" => {
-                      "value" => "MODS issuance terms"
-                    }
-                  },
-                  {
-                    "value" => "Weekly",
-                    "type" => "frequency"
-                  }
-                ]
+                "value" => "1866-02-22",
+                "type" => "publication",
+                "status" => "primary",
+                "encoding" => {
+                  "code" => "w3cdtf"
+                }
+              }
+            ],
+            "location" => [
+              {
+                "code" => "nyu",
+                "source" => {
+                  "code" => "marccountry"
+                }
+              }
+            ],
+            "note" => [
+              {
+                "value" => "serial",
+                "type" => "issuance",
+                "source" => {
+                  "value" => "MODS issuance terms"
+                }
               },
               {
-                "contributor" => [
+                "value" => "Weekly",
+                "type" => "frequency"
+              }
+            ]
+          },
+          {
+            "contributor" => [
+              {
+                "name" => [
                   {
-                    "name" => [
-                      {
-                        "value" => "Street and Smith"
-                      }
-                    ],
-                    "type" => "organization",
-                    "role" => [
-                      {
-                        "value" => "publisher",
-                        "code" => "pbl",
-                        "uri" => "http://id.loc.gov/vocabulary/relators/pbl",
-                        "source" => {
-                          "code" => "marcrelator",
-                          "uri" => "http://id.loc.gov/vocabulary/relators/"
-                        }
-                      }
-                    ]
+                    "value" => "Street and Smith"
                   }
                 ],
-                "location" => [
+                "type" => "organization",
+                "role" => [
                   {
-                    "value" => "New York, N.Y."
+                    "value" => "publisher",
+                    "code" => "pbl",
+                    "uri" => "http://id.loc.gov/vocabulary/relators/pbl",
+                    "source" => {
+                      "code" => "marcrelator",
+                      "uri" => "http://id.loc.gov/vocabulary/relators/"
+                    }
                   }
                 ]
               }
+            ],
+            "location" => [
+              {
+                "value" => "New York, N.Y."
+              }
             ]
           }
-        }
+        ]
       end
 
       it "uses the date/event type as the heading and includes notes in the value" do
@@ -1013,47 +1033,66 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       end
     end
 
-    context "with an imprint" do
-      let(:cocina) do
-        {
-          "description" => {
-            "event" => [
+    context "with one event and one imprint" do
+      # from druid:bm971cx9348
+      let(:events) do
+        [
+          {
+            "date" => [
               {
-                "date" => [
-                  {"value" => "[192-?]-[193-?]", "type" => "publication"}
+                "structuredValue" => [
+                  {"value" => "1920", "type" => "start"}
                 ],
-                "location" => [
-                  {"value" => "London"}
-                ],
-                "contributor" => [
-                  {
-                    "name" => [
-                      {"value" => "H.M. Stationery Off."}
-                    ],
-                    "role" => [
-                      {
-                        "value" => "publisher",
-                        "code" => "pbl",
-                        "uri" => "http://id.loc.gov/vocabulary/relators/pbl",
-                        "source" => {
-                          "code" => "marcrelator",
-                          "uri" => "http://id.loc.gov/vocabulary/relators/"
-                        }
-                      }
-                    ],
-                    "type" => "organization"
-                  }
-                ]
+                "type" => "publication",
+                "encoding" => {"code" => "marc"}
               }
+            ],
+            "location" => [
+              {"code" => "enk", "source" => {"code" => "marccountry"}}
+            ],
+            "note" => [
+              {"type" => "issuance", "value" => "monographic", "source" => {"value" => "MODS issuance terms"}}
+            ]
+          },
+          {
+            "date" => [
+              {"value" => "[192-?]-[193-?]", "type" => "publication"}
+            ],
+            "note" => [
+              {"type" => "edition", "value" => "2nd ed."}
+            ],
+            "contributor" => [
+              {
+                "name" => [
+                  {"value" => "H.M. Stationery Off."}
+                ],
+                "role" => [
+                  {
+                    "value" => "publisher",
+                    "code" => "pbl",
+                    "uri" => "http://id.loc.gov/vocabulary/relators/pbl",
+                    "source" => {
+                      "code" => "marcrelator",
+                      "uri" => "http://id.loc.gov/vocabulary/relators/"
+                    }
+                  }
+                ],
+                "type" => "organization"
+              }
+            ],
+            "location" => [
+              {"value" => "London"},
+              {"source" => {"code" => "marccountry"}, "code" => "enk"}
             ]
           }
-        }
+        ]
       end
 
       it "returns the imprint under an imprint heading" do
         expect(subject).to eq(
           {
-            "Imprint" => ["London : H.M. Stationery Off., [192-?]-[193-?]"]
+            "Publication" => ["England, 1920 -"],
+            "Imprint" => ["2nd ed. - London : H.M. Stationery Off., [192-?]-[193-?]"]
           }
         )
       end
@@ -1092,7 +1131,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       it "uses the event displayLabel as the heading" do
         expect(subject).to eq(
           {
-            "Court location and trial date" => ["Ludwigsberg (Germany), 02/06/1946 - 03/22/1946"]
+            "Court location and trial date" => ["Ludwigsberg (Germany), February 6, 1946 - March 22, 1946"]
           }
         )
       end

--- a/spec/events/event_spec.rb
+++ b/spec/events/event_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe CocinaDisplay::Events::Event do
           }
         end
 
-        it "concatenates and orders all valid dates" do
-          is_expected.to eq "no date here; 18th century; September 1920"
+        it "concatenates and orders all dates" do
+          is_expected.to eq "Unknown, 18th century, and September 1920"
         end
       end
 
@@ -81,8 +81,8 @@ RSpec.describe CocinaDisplay::Events::Event do
           }
         end
 
-        it "prefers the unencoded date to preserve punctuation-as-metadata" do
-          is_expected.to eq "1920]"
+        it "prefers the encoded date for clarity" do
+          is_expected.to eq "1920"
         end
       end
 
@@ -120,44 +120,6 @@ RSpec.describe CocinaDisplay::Events::Event do
 
         it "renders the range" do
           is_expected.to eq "1920 - 1921"
-        end
-      end
-
-      # from druid:zs247rr8237
-      context "with two distinct dates" do
-        let(:cocina) do
-          {
-            "date" => [
-              {
-                "value" => "1674",
-                "type" => "creation",
-                "status" => "primary",
-                "qualifier" => "approximate"
-              },
-              {
-                "structuredValue" => [
-                  {
-                    "value" => "1690",
-                    "type" => "end"
-                  }
-                ],
-                "type" => "creation",
-                "encoding" => {
-                  "code" => "w3cdtf"
-                },
-                "qualifier" => "approximate"
-              }
-            ],
-            "location" => [
-              {
-                "value" => "[Italy?]"
-              }
-            ]
-          }
-        end
-
-        it "lists them separately, in order" do
-          is_expected.to eq "[Italy?], [ca. 1674]; [ca. - 1690]"
         end
       end
     end
@@ -210,8 +172,8 @@ RSpec.describe CocinaDisplay::Events::Event do
           }
         end
 
-        it "prefers the unencoded place name" do
-          is_expected.to eq "London, 1921"
+        it "uses all place names" do
+          is_expected.to eq "London, England, 1921"
         end
       end
 
@@ -268,123 +230,6 @@ RSpec.describe CocinaDisplay::Events::Event do
 
       it "renders everything correctly" do
         is_expected.to eq "London, 1921"
-      end
-    end
-
-    context "with a publisher and date" do
-      let(:cocina) do
-        {
-          "date" => [
-            {"value" => "1921.", "type" => "publication"}
-          ],
-          "contributor" => [
-            {
-              "name" => [{"value" => "Chronicle Books"}],
-              "role" => [{"value" => "publisher"}]
-            }
-          ]
-        }
-      end
-
-      it "renders everything correctly" do
-        is_expected.to eq "Chronicle Books, 1921."
-      end
-    end
-
-    context "with multiple publication places" do
-      let(:cocina) do
-        {
-          "date" => [
-            {"value" => "1921.", "type" => "publication"}
-          ],
-          "location" => [
-            {"value" => "London"},
-            {"value" => "England"}
-          ]
-        }
-      end
-
-      it "renders everything correctly" do
-        is_expected.to eq "London : England, 1921."
-      end
-    end
-
-    context "with a place, publisher, and date" do
-      # from druid:bg262qk2288
-      let(:cocina) do
-        {
-          "date" => [
-            {"value" => "[1862]-", "type" => "publication"}
-          ],
-          "contributor" => [
-            {
-              "name" => [
-                {"value" => "Librairie administrative de P. Dupont"}
-              ],
-              "type" => "organization",
-              "role" => [
-                {
-                  "value" => "publisher",
-                  "code" => "pbl",
-                  "uri" => "http://id.loc.gov/vocabulary/relators/pbl",
-                  "source" => {"code" => "marcrelator", "uri" => "http://id.loc.gov/vocabulary/relators/"}
-                }
-              ]
-            }
-          ],
-          "location" => [
-            {"value" => "Paris"}
-          ]
-        }
-      end
-
-      it "renders everything correctly" do
-        # MARC may have had a comma after the place, but Cocina does not include it
-        is_expected.to eq "Paris : Librairie administrative de P. Dupont, [1862]-"
-      end
-    end
-
-    context "with an edition, publisher, place, and date" do
-      # adapted from druid:bm971cx9348
-      let(:cocina) do
-        {
-          "type" => "publication",
-          "date" => [
-            {"value" => "[192-?]-[193-?]", "type" => "publication"},
-            {"structuredValue" => [{"value" => "1920", "type" => "start"}], "encoding" => {"code" => "marc"}, "type" => "publication"}
-          ],
-          "note" => [
-            {"type" => "edition", "value" => "2nd ed."}
-          ],
-          "contributor" => [
-            {
-              "name" => [
-                {"value" => "H.M. Stationery Off."}
-              ],
-              "role" => [
-                {
-                  "value" => "publisher",
-                  "code" => "pbl",
-                  "uri" => "http://id.loc.gov/vocabulary/relators/pbl",
-                  "source" => {
-                    "code" => "marcrelator",
-                    "uri" => "http://id.loc.gov/vocabulary/relators/"
-                  }
-                }
-              ],
-              "type" => "organization"
-            }
-          ],
-          "location" => [
-            {"value" => "London"},
-            {"source" => {"code" => "marccountry"}, "code" => "enk"}
-          ]
-        }
-      end
-
-      it "renders everything correctly" do
-        # Prefers the unencoded place name and date
-        is_expected.to eq "2nd ed. - London : H.M. Stationery Off., [192-?]-[193-?]"
       end
     end
   end

--- a/spec/events/imprint_spec.rb
+++ b/spec/events/imprint_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CocinaDisplay::Events::Imprint do
+  subject(:imprint) { described_class.new(cocina) }
+
+  describe "#to_s" do
+    subject { imprint.to_s }
+
+    describe "date processing" do
+      context "with several date types and formats" do
+        let(:cocina) do
+          {
+            "date" => [
+              {"value" => "17uu", "type" => "publication", "encoding" => {"code" => "edtf"}},
+              {"value" => "no date here", "type" => "creation"},
+              {"value" => "1920-09", "type" => "capture", "encoding" => {"code" => "w3cdtf"}}
+            ]
+          }
+        end
+
+        it "concatenates and orders all dates, respecting original value" do
+          is_expected.to eq "no date here; 18th century; September 1920"
+        end
+      end
+
+      context "with a mix of unencoded and encoded dates" do
+        let(:cocina) do
+          {
+            "date" => [
+              {"value" => "1920", "type" => "publication", "encoding" => {"code" => "edtf"}},
+              {"value" => "1920]", "type" => "publication"}
+            ]
+          }
+        end
+
+        it "prefers the unencoded date to preserve punctuation-as-metadata" do
+          is_expected.to eq "1920]"
+        end
+      end
+
+      context "when there are duplicate dates" do
+        let(:cocina) do
+          {
+            "date" => [
+              {"value" => "1920", "type" => "publication", "encoding" => {"code" => "edtf"}},
+              {"value" => "1920", "type" => "publication", "encoding" => {"code" => "marc"}},
+              {"value" => "1920", "type" => "publication"}
+            ]
+          }
+        end
+
+        it "deduplicates them" do
+          is_expected.to eq "1920"
+        end
+      end
+
+      # from druid:zs247rr8237
+      context "with two distinct dates" do
+        let(:cocina) do
+          {
+            "date" => [
+              {
+                "value" => "1674",
+                "type" => "creation",
+                "status" => "primary",
+                "qualifier" => "approximate"
+              },
+              {
+                "structuredValue" => [
+                  {
+                    "value" => "1690",
+                    "type" => "end"
+                  }
+                ],
+                "type" => "creation",
+                "encoding" => {
+                  "code" => "w3cdtf"
+                },
+                "qualifier" => "approximate"
+              }
+            ],
+            "location" => [
+              {
+                "value" => "[Italy?]"
+              }
+            ]
+          }
+        end
+
+        it "lists them separately, in order" do
+          is_expected.to eq "[Italy?], [ca. 1674]; [ca. - 1690]"
+        end
+      end
+    end
+
+    describe "location processing" do
+      context "with unencoded and encoded place names" do
+        let(:cocina) do
+          {
+            "date" => [
+              {"value" => "1921", "type" => "publication"}
+            ],
+            "location" => [
+              {"value" => "London"},
+              {"source" => {"code" => "marccountry"}, "code" => "enk"}
+            ]
+          }
+        end
+
+        it "prefers the unencoded place name" do
+          is_expected.to eq "London, 1921"
+        end
+      end
+    end
+
+    context "with multiple publication places" do
+      let(:cocina) do
+        {
+          "date" => [
+            {"value" => "1921.", "type" => "publication"}
+          ],
+          "location" => [
+            {"value" => "London"},
+            {"value" => "England"}
+          ]
+        }
+      end
+
+      it "separates using a colon" do
+        is_expected.to eq "London : England, 1921."
+      end
+    end
+
+    context "with a place, publisher, and date" do
+      # from druid:bg262qk2288
+      let(:cocina) do
+        {
+          "date" => [
+            {"value" => "[1862]-", "type" => "publication"}
+          ],
+          "contributor" => [
+            {
+              "name" => [
+                {"value" => "Librairie administrative de P. Dupont"}
+              ],
+              "type" => "organization",
+              "role" => [
+                {
+                  "value" => "publisher",
+                  "code" => "pbl",
+                  "uri" => "http://id.loc.gov/vocabulary/relators/pbl",
+                  "source" => {"code" => "marcrelator", "uri" => "http://id.loc.gov/vocabulary/relators/"}
+                }
+              ]
+            }
+          ],
+          "location" => [
+            {"value" => "Paris"}
+          ]
+        }
+      end
+
+      it "renders everything correctly" do
+        # MARC may have had a comma after the place, but Cocina does not include it
+        is_expected.to eq "Paris : Librairie administrative de P. Dupont, [1862]-"
+      end
+    end
+
+    context "with an edition, publisher, place, and date" do
+      # adapted from druid:bm971cx9348
+      let(:cocina) do
+        {
+          "type" => "publication",
+          "date" => [
+            {"value" => "[192-?]-[193-?]", "type" => "publication"},
+            {"structuredValue" => [{"value" => "1920", "type" => "start"}], "encoding" => {"code" => "marc"}, "type" => "publication"}
+          ],
+          "note" => [
+            {"type" => "edition", "value" => "2nd ed."}
+          ],
+          "contributor" => [
+            {
+              "name" => [
+                {"value" => "H.M. Stationery Off."}
+              ],
+              "role" => [
+                {
+                  "value" => "publisher",
+                  "code" => "pbl",
+                  "uri" => "http://id.loc.gov/vocabulary/relators/pbl",
+                  "source" => {
+                    "code" => "marcrelator",
+                    "uri" => "http://id.loc.gov/vocabulary/relators/"
+                  }
+                }
+              ],
+              "type" => "organization"
+            }
+          ],
+          "location" => [
+            {"value" => "London"},
+            {"source" => {"code" => "marccountry"}, "code" => "enk"}
+          ]
+        }
+      end
+
+      it "renders everything correctly" do
+        # Prefers the unencoded place name and date
+        is_expected.to eq "2nd ed. - London : H.M. Stationery Off., [192-?]-[193-?]"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This alters the non-Imprint string form for Events to be a little
more readable, and also prevents some simple types of Events from
being detected as Imprints.

Because the #to_s implementations ended up diverging, the Imprint
class is resurrected to handle the differences.
