### PR TITLE
Handling for parallelValued Subjects

### DIFF
--- a/lib/cocina_display/concerns/geospatial.rb
+++ b/lib/cocina_display/concerns/geospatial.rb
@@ -8,7 +8,7 @@ module CocinaDisplay
       # @return [Array<String>]
       # @example ["34°03′08″N 118°14′37″W"]
       def coordinates
-        coordinate_subject_values.map(&:to_s).compact.uniq
+        coordinate_subject_parts.map(&:to_s).compact.uniq
       end
 
       # All valid coordinate data formatted for indexing into a Solr RPT field.
@@ -43,7 +43,7 @@ module CocinaDisplay
       # @return [Array<String>]
       # @example ["6252001", "5368361"]
       def geonames_ids
-        place_subject_values.map { |s| s.geonames_id }.compact.uniq
+        place_subject_parts.map { |s| s.geonames_id }.compact.uniq
       end
 
       private
@@ -54,16 +54,16 @@ module CocinaDisplay
         all_subjects.filter { |subject| subject.type&.include? "coordinates" }
       end
 
-      # Parsed coordinate values from the coordinate subject values.
+      # Parsed coordinate values from the coordinate subject parts.
       # @return [Array<Geospatial::Coordinates>]
       def coordinate_objects
-        coordinate_subject_values.filter_map(&:coordinates)
+        coordinate_subject_parts.filter_map(&:coordinates)
       end
 
-      # All subject values that could contain parsed coordinates.
-      # @return [Array<Subjects::CoordinatesSubjectValue>]
-      def coordinate_subject_values
-        subject_values.filter { |s| s.is_a? CocinaDisplay::Subjects::CoordinatesSubjectValue }
+      # All subject parts that could contain parsed coordinates.
+      # @return [Array<Subjects::CoordinatesSubjectPart>]
+      def coordinate_subject_parts
+        subject_parts.filter { |s| s.is_a? CocinaDisplay::Subjects::CoordinatesSubjectPart }
       end
     end
   end

--- a/lib/cocina_display/concerns/subjects.rb
+++ b/lib/cocina_display/concerns/subjects.rb
@@ -2,51 +2,51 @@ module CocinaDisplay
   module Concerns
     # Methods for extracting and formatting subject information.
     module Subjects
-      # All unique subject values that are topics.
+      # All unique subject parts that are topics.
       # @return [Array<String>]
       def subject_topics
-        subject_values.filter { |s| s.type == "topic" }.map(&:to_s).uniq
+        subject_parts.filter { |s| s.type == "topic" }.map(&:to_s).uniq
       end
 
-      # All unique subject values that are genres.
+      # All unique subject parts that are genres.
       # @return [Array<String>]
       def subject_genres
-        subject_values.filter { |s| s.type == "genre" }.map(&:to_s).uniq
+        subject_parts.filter { |s| s.type == "genre" }.map(&:to_s).uniq
       end
 
-      # All unique subject values that are titles.
+      # All unique subject parts that are titles.
       # @return [Array<String>]
       def subject_titles
-        subject_values.filter { |s| s.type == "title" }.map(&:to_s).uniq
+        subject_parts.filter { |s| s.type == "title" }.map(&:to_s).uniq
       end
 
-      # All unique subject values that are date/time info.
+      # All unique subject parts that are date/time info.
       # @return [Array<String>]
       def subject_temporal
-        subject_values.filter { |s| s.type == "time" }.map(&:to_s).uniq
+        subject_parts.filter { |s| s.type == "time" }.map(&:to_s).uniq
       end
 
-      # All unique subject values that are occupations.
+      # All unique subject parts that are occupations.
       # @return [Array<String>]
       def subject_occupations
-        subject_values.filter { |s| s.type == "occupation" }.map(&:to_s).uniq
+        subject_parts.filter { |s| s.type == "occupation" }.map(&:to_s).uniq
       end
 
-      # All unique subject values that are named geographic places.
+      # All unique subject parts that are named geographic places.
       # @return [Array<String>]
       def subject_places
-        place_subject_values.map(&:to_s).uniq
+        place_subject_parts.map(&:to_s).uniq
       end
 
-      # All unique subject values that are names of entities.
+      # All unique subject parts that are names of entities.
       # @note Multiple types are handled: person, family, organization, conference, etc.
-      # @see CocinaDisplay::NameSubjectValue
+      # @see CocinaDisplay::NameSubjectPart
       # @return [Array<String>]
       def subject_names
-        subject_values.filter { |s| s.is_a? CocinaDisplay::Subjects::NameSubjectValue }.map(&:to_s).uniq
+        subject_parts.filter { |s| s.is_a? CocinaDisplay::Subjects::NameSubjectPart }.map(&:to_s).uniq
       end
 
-      # Combination of all subject values for searching.
+      # Combination of all subject parts for searching.
       # @see #subject_topics_other
       # @see #subject_temporal_genre
       # @see #subject_places
@@ -55,7 +55,7 @@ module CocinaDisplay
         subject_topics_other + subject_temporal_genre + subject_places
       end
 
-      # Combination of topic, occupation, name, and title subject values for searching.
+      # Combination of topic, occupation, name, and title subject parts for searching.
       # @see #subject_topics
       # @see #subject_other
       # @return [Array<String>]
@@ -63,7 +63,7 @@ module CocinaDisplay
         subject_topics + subject_other
       end
 
-      # Combination of occupation, name, and title subject values for searching.
+      # Combination of occupation, name, and title subject parts for searching.
       # @see #subject_occupations
       # @see #subject_names
       # @see #subject_titles
@@ -72,7 +72,7 @@ module CocinaDisplay
         subject_occupations + subject_names + subject_titles
       end
 
-      # Combination of temporal and genre subject values for searching.
+      # Combination of temporal and genre subject parts for searching.
       # @see #subject_temporal
       # @see #subject_genres
       # @return [Array<String>]
@@ -88,7 +88,7 @@ module CocinaDisplay
       end
 
       # Subject data to be rendered for display.
-      # Uses the concatenated form for structured subject values.
+      # Uses the concatenated form for structured subject parts.
       # @see Subject#to_s
       # @return [Array<DisplayData>]
       def subject_display_data
@@ -119,16 +119,16 @@ module CocinaDisplay
         all_subjects.filter { |subject| subject.type == "classification" }
       end
 
-      # All subject values, flattened from all subjects.
-      # @return [Array<SubjectValue>]
-      def subject_values
-        @subject_values ||= all_subjects.flat_map(&:subject_values)
+      # All subject parts, flattened from all subjects.
+      # @return [Array<SubjectPart>]
+      def subject_parts
+        @subject_parts ||= all_subjects.flat_map(&:parallel_values).flat_map(&:subject_parts)
       end
 
-      # All subject values that are named places.
-      # @return [Array<PlaceSubjectValue>]
-      def place_subject_values
-        @place_subject_values ||= subject_values.filter { |s| s.is_a? CocinaDisplay::Subjects::PlaceSubjectValue }
+      # All subject parts that are named places.
+      # @return [Array<PlaceSubjectPart>]
+      def place_subject_parts
+        @place_subject_parts ||= subject_parts.filter { |s| s.is_a? CocinaDisplay::Subjects::PlaceSubjectPart }
       end
     end
   end

--- a/lib/cocina_display/parallel/parallel.rb
+++ b/lib/cocina_display/parallel/parallel.rb
@@ -47,12 +47,14 @@ module CocinaDisplay
       # The main value among the parallel values, according to these rules:
       # 1. If there's a parallelValue with type "display", use that.
       # 2. If there's a parallelValue marked as primary, use that.
-      # 3. If there's a parallelValue with a non-role type, like "alternative", use that.
-      # 4. Otherwise, use the first parallelValue.
+      # 3. If there's a parallelValue in a vernacular (non-English) language, use that.
+      # 4. If there's a parallelValue with a non-role type, like "alternative", use that.
+      # 5. Otherwise, use the first parallelValue.
       # @return [CocinaDisplay::ParallelValue, nil]
       def main_value
         parallel_values.find(&:display?) ||
           parallel_values.find(&:primary?) ||
+          parallel_values.find(&:vernacular?) ||
           parallel_values.find(&:own_typed?) ||
           parallel_values.first
       end
@@ -79,6 +81,18 @@ module CocinaDisplay
       # @return [Boolean]
       def has_transliteration?
         transliterated_value.present?
+      end
+
+      # The vernacular (non-English) version of the object, if any.
+      # @return [CocinaDisplay::ParallelValue, nil]
+      def vernacular_value
+        parallel_values.find(&:vernacular?)
+      end
+
+      # Is there a vernacular (non-English) version of the object?
+      # @return [Boolean]
+      def has_vernacular?
+        vernacular_value.present?
       end
 
       # The status of the object relative to others, if any (e.g., "primary").

--- a/lib/cocina_display/parallel/parallel_value.rb
+++ b/lib/cocina_display/parallel/parallel_value.rb
@@ -43,10 +43,18 @@ module CocinaDisplay
         role == "display"
       end
 
+      # Is this value in a native (non-English) language?
+      # @return [Boolean]
+      def vernacular?
+        language.present? && !language.english?
+      end
+
       # Is this value translated?
+      # True if the role is "translated" or "translation", or if there is
+      # a parallel vernacular value but this one is in English.
       # @return [Boolean]
       def translated?
-        role == "translated" || role == "translation"
+        role == "translated" || role == "translation" || (siblings.any?(&:vernacular?) && language&.english?)
       end
 
       # Is this value transliterated?

--- a/lib/cocina_display/subjects/subject.rb
+++ b/lib/cocina_display/subjects/subject.rb
@@ -1,68 +1,23 @@
 module CocinaDisplay
   module Subjects
-    # Base class for subjects in Cocina structured data.
-    class Subject
-      attr_reader :cocina, :delimiter
+    # A Subject in Cocina structured data, possibly in multiple languages.
+    class Subject < Parallel::Parallel
+      # String representation uses the main parallel value.
+      delegate :to_s, to: :main_value
 
-      # Initialize a Subject object with Cocina structured data.
-      # @param cocina [Hash] The Cocina structured data for the subject.
-      # @param delimiter [String] The delimiter to use when flattening for display
-      def initialize(cocina, delimiter: " > ")
-        @cocina = cocina
-        @delimiter = delimiter
-      end
-
-      # The top-level type of the subject.
-      # @see https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md#subject-types
-      # @return [String, nil]
-      def type
-        cocina["type"]
-      end
-
-      # Array of display strings for each value in the subject.
-      # Used for search, where each value should be indexed separately.
-      # @return [Array<String>]
-      def values
-        subject_values.map(&:to_s).compact_blank
-      end
-
-      # The value to use for display.
-      # Genre values are capitalized; other subject values are not.
-      # @return [String]
-      def to_s
-        (type == "genre") ? flat_value&.upcase_first : flat_value
-      end
-
-      # A string representation of the entire subject, concatenated for display.
-      # @return [String]
-      def flat_value
-        Utils.compact_and_join(values, delimiter: delimiter)
-      end
-
-      # Label used to render the subject for display.
-      # Uses a displayLabel if available, otherwise looks up via type.
+      # Label used when displaying the Subject.
       # @return [String]
       def label
-        cocina["displayLabel"].presence || type_label
-      end
-
-      # Individual values composing this subject.
-      # Can be multiple if the Cocina featured nested data.
-      # All SubjectValues inherit the type of their parent Subject.
-      # @return [Array<SubjectValue>]
-      def subject_values
-        @subject_values ||= (Array(cocina["parallelValue"]).presence || [cocina]).flat_map do |node|
-          if SubjectValue.atomic_types.include?(type)
-            SubjectValue.from_cocina(node, type: type)
-          else
-            Utils.flatten_nested_values(node, atomic_types: SubjectValue.atomic_types).flat_map do |value|
-              SubjectValue.from_cocina(value, type: value["type"] || type)
-            end
-          end
-        end
+        display_label || type_label
       end
 
       private
+
+      # The class to use for the parallel values that make up this subject.
+      # @return [Class]
+      def parallel_value_class
+        SubjectValue
+      end
 
       # Type-specific label for this subject.
       # @return [String]

--- a/lib/cocina_display/subjects/subject_part.rb
+++ b/lib/cocina_display/subjects/subject_part.rb
@@ -1,0 +1,177 @@
+module CocinaDisplay
+  module Subjects
+    # A descriptive value that can be part of a structured Subject.
+    class SubjectPart
+      attr_reader :cocina
+
+      # The type of the subject part, like "person", "title", or "time".
+      # @see https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md#subject-part-types-for-structured-value
+      attr_accessor :type
+
+      # Create SubjectParts from Cocina structured data.
+      # Pre-coordinated string values will be split into multiple SubjectParts.
+      # @param cocina [Hash] The Cocina structured data for the subject.
+      # @param type [String, nil] The type, coming from the parent Subject.
+      # @return [Array<SubjectPart>]
+      def self.from_cocina(cocina, type:)
+        split_pre_coordinated_values(cocina, type: type).map do |value|
+          SUBJECT_PART_TYPES.fetch(type, SubjectPart).new(value).tap do |obj|
+            obj.type ||= type
+          end
+        end
+      end
+
+      # Split a pre-coordinated subject value joined with "--" into multiple values.
+      # Ignores the "--" string for coordinate subject types, which use it differently.
+      # @param cocina [Hash] The Cocina structured data for the subject.
+      # @return [Array<Hash>] An array of Cocina hashes, one for each split value
+      def self.split_pre_coordinated_values(cocina, type:)
+        if cocina["value"].is_a?(String) && cocina["value"].include?("--") && !type&.include?("coordinates")
+          cocina["value"].split("--").map { |v| cocina.merge("value" => v.strip) }
+        else
+          [cocina]
+        end
+      end
+
+      # All subject part types that should not be further destructured.
+      # @return [Array<String>]
+      def self.atomic_types
+        SUBJECT_PART_TYPES.keys - ["place"]
+      end
+
+      # Initialize a SubjectPart object with Cocina structured data.
+      # @param cocina [Hash] The Cocina structured data for the subject part.
+      def initialize(cocina)
+        @cocina = cocina
+        @type = cocina["type"]
+      end
+
+      # The display string for the subject part.
+      # Subclasses should override this method to provide specific formatting.
+      # @return [String]
+      def to_s
+        cocina["value"]
+      end
+    end
+
+    # A subject part representing a named entity.
+    class NameSubjectPart < SubjectPart
+      attr_reader :name
+
+      # Initialize a NameSubjectPart object with Cocina structured data.
+      # @param cocina [Hash] The Cocina structured data for the subject part.
+      def initialize(cocina)
+        super
+        @name = Contributors::Name.new(cocina)
+      end
+
+      # Use the contributor name formatting rules for display.
+      # @return [String] The formatted name string, including life dates
+      # @see CocinaDisplay::Contributor::Name#to_s
+      def to_s
+        name.to_s(with_date: true)
+      end
+    end
+
+    # A subject part representing an entity with a title.
+    class TitleSubjectPart < SubjectPart
+      attr_reader :title
+
+      # Initialize a TitleSubjectPart object with Cocina structured data.
+      # @param cocina [Hash] The Cocina structured data for the subject part.
+      def initialize(cocina)
+        super
+        @title = Titles::Title.new(cocina)
+      end
+
+      # Construct a title string to use for display.
+      # @see CocinaDisplay::Title#to_s
+      # @return [String, nil]
+      def to_s
+        title.to_s
+      end
+    end
+
+    # A subject part representing a date and/or time.
+    class TemporalSubjectPart < SubjectPart
+      attr_reader :date
+
+      def initialize(cocina)
+        super
+        @date = Dates::Date.from_cocina(cocina)
+      end
+
+      # @return [String] The formatted date/time string for display
+      def to_s
+        date.to_s
+      end
+    end
+
+    # A subject part representing a named place.
+    class PlaceSubjectPart < SubjectPart
+      # A URI identifying the place, if available.
+      # @return [String, nil]
+      def uri
+        cocina["uri"]
+      end
+
+      # True if the place has a geonames.org URI.
+      # @return [Boolean]
+      def geonames?
+        uri&.include?("sws.geonames.org")
+      end
+
+      # Unique identifier for the place in geonames.org.
+      # @return [String, nil]
+      def geonames_id
+        uri&.split("/")&.last if geonames?
+      end
+    end
+
+    # A subject part containing geographic coordinates, like a point or box.
+    class CoordinatesSubjectPart < SubjectPart
+      attr_reader :coordinates
+
+      def initialize(cocina)
+        super
+        @coordinates = Geospatial::Coordinates.from_cocina(cocina)
+      end
+
+      # The normalized DMS string for the coordinates.
+      # Falls back to the raw value if parsing fails.
+      # @return [String, nil]
+      def to_s
+        coordinates&.to_s || super
+      end
+    end
+  end
+end
+
+# Map Cocina subject part types to specific SubjectPart classes for rendering.
+# @see SubjectPart#type
+SUBJECT_PART_TYPES = {
+  "person" => CocinaDisplay::Subjects::NameSubjectPart,
+  "family" => CocinaDisplay::Subjects::NameSubjectPart,
+  "organization" => CocinaDisplay::Subjects::NameSubjectPart,
+  "conference" => CocinaDisplay::Subjects::NameSubjectPart,
+  "event" => CocinaDisplay::Subjects::NameSubjectPart,
+  "name" => CocinaDisplay::Subjects::NameSubjectPart,
+  "title" => CocinaDisplay::Subjects::TitleSubjectPart,
+  "time" => CocinaDisplay::Subjects::TemporalSubjectPart,
+  "area" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "city" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "city section" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "continent" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "country" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "county" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "coverage" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "extraterrestrial area" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "island" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "place" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "region" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "state" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "territory" => CocinaDisplay::Subjects::PlaceSubjectPart,
+  "point coordinates" => CocinaDisplay::Subjects::CoordinatesSubjectPart,
+  "map coordinates" => CocinaDisplay::Subjects::CoordinatesSubjectPart,
+  "bounding box coordinates" => CocinaDisplay::Subjects::CoordinatesSubjectPart
+}.freeze

--- a/lib/cocina_display/subjects/subject_value.rb
+++ b/lib/cocina_display/subjects/subject_value.rb
@@ -1,177 +1,46 @@
 module CocinaDisplay
   module Subjects
-    # A descriptive value that can be part of a Subject.
-    class SubjectValue
-      attr_reader :cocina
-
-      # The type of the subject value, like "person", "title", or "time".
-      # @see https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md#subject-part-types-for-structured-value
-      attr_accessor :type
-
-      # Create SubjectValues from Cocina structured data.
-      # Pre-coordinated string values will be split into multiple SubjectValues.
-      # @param cocina [Hash] The Cocina structured data for the subject.
-      # @param type [String, nil] The type, coming from the parent Subject.
-      # @return [Array<SubjectValue>]
-      def self.from_cocina(cocina, type:)
-        split_pre_coordinated_values(cocina, type: type).map do |value|
-          SUBJECT_VALUE_TYPES.fetch(type, SubjectValue).new(value).tap do |obj|
-            obj.type ||= type
-          end
-        end
-      end
-
-      # Split a pre-coordinated subject value joined with "--" into multiple values.
-      # Ignores the "--" string for coordinate subject types, which use it differently.
-      # @param cocina [Hash] The Cocina structured data for the subject.
-      # @return [Array<Hash>] An array of Cocina hashes, one for each split value
-      def self.split_pre_coordinated_values(cocina, type:)
-        if cocina["value"].is_a?(String) && cocina["value"].include?("--") && !type&.include?("coordinates")
-          cocina["value"].split("--").map { |v| cocina.merge("value" => v.strip) }
-        else
-          [cocina]
-        end
-      end
-
-      # All subject value types that should not be further destructured.
+    # A subject in Cocina structured data in a single language/script.
+    class SubjectValue < Parallel::ParallelValue
+      # Array of display strings for each part of the subject.
+      # Used for search, where each value should be indexed separately.
       # @return [Array<String>]
-      def self.atomic_types
-        SUBJECT_VALUE_TYPES.keys - ["place"]
+      def values
+        subject_parts.map(&:to_s).compact_blank
       end
 
-      # Initialize a SubjectValue object with Cocina structured data.
-      # @param cocina [Hash] The Cocina structured data for the subject value.
-      def initialize(cocina)
-        @cocina = cocina
-        @type = cocina["type"]
-      end
-
-      # The display string for the subject value.
-      # Subclasses should override this method to provide specific formatting.
+      # The value to use for display.
+      # Genre values are capitalized; other subject values are not.
       # @return [String]
       def to_s
-        cocina["value"]
-      end
-    end
-
-    # A subject value representing a named entity.
-    class NameSubjectValue < SubjectValue
-      attr_reader :name
-
-      # Initialize a NameSubjectValue object with Cocina structured data.
-      # @param cocina [Hash] The Cocina structured data for the subject.
-      def initialize(cocina)
-        super
-        @name = Contributors::Name.new(cocina)
+        (type == "genre") ? flat_value&.upcase_first : flat_value
       end
 
-      # Use the contributor name formatting rules for display.
-      # @return [String] The formatted name string, including life dates
-      # @see CocinaDisplay::Contributor::Name#to_s
-      def to_s
-        name.to_s(with_date: true)
-      end
-    end
-
-    # A subject value representing an entity with a title.
-    class TitleSubjectValue < SubjectValue
-      attr_reader :title
-
-      # Initialize a TitleSubjectValue object with Cocina structured data.
-      # @param cocina [Hash] The Cocina structured data for the subject.
-      def initialize(cocina)
-        super
-        @title = Titles::Title.new(cocina)
+      # A string representation of the entire subject, concatenated for display.
+      # @return [String]
+      def flat_value
+        Utils.compact_and_join(values, delimiter: delimiter)
       end
 
-      # Construct a title string to use for display.
-      # @see CocinaDisplay::Title#to_s
-      # @return [String, nil]
-      def to_s
-        title.to_s
-      end
-    end
-
-    # A subject value representing a date and/or time.
-    class TemporalSubjectValue < SubjectValue
-      attr_reader :date
-
-      def initialize(cocina)
-        super
-        @date = Dates::Date.from_cocina(cocina)
+      # Delimiter used to join the individual parts of the subject for display.
+      # @return [String]
+      def delimiter
+        " > "
       end
 
-      # @return [String] The formatted date/time string for display
-      def to_s
-        date.to_s
-      end
-    end
-
-    # A subject value representing a named place.
-    class PlaceSubjectValue < SubjectValue
-      # A URI identifying the place, if available.
-      # @return [String, nil]
-      def uri
-        cocina["uri"]
-      end
-
-      # True if the place has a geonames.org URI.
-      # @return [Boolean]
-      def geonames?
-        uri&.include?("sws.geonames.org")
-      end
-
-      # Unique identifier for the place in geonames.org.
-      # @return [String, nil]
-      def geonames_id
-        uri&.split("/")&.last if geonames?
-      end
-    end
-
-    # A subject value containing geographic coordinates, like a point or box.
-    class CoordinatesSubjectValue < SubjectValue
-      attr_reader :coordinates
-
-      def initialize(cocina)
-        super
-        @coordinates = Geospatial::Coordinates.from_cocina(cocina)
-      end
-
-      # The normalized DMS string for the coordinates.
-      # Falls back to the raw value if parsing fails.
-      # @return [String, nil]
-      def to_s
-        coordinates&.to_s || super
+      # Individual SubjectParts composing this subject.
+      # Can be multiple if the Cocina featured structuredValues.
+      # All SubjectParts inherit the type of their parent Subject.
+      # @return [Array<SubjectPart>]
+      def subject_parts
+        @subject_parts ||= if SubjectPart.atomic_types.include?(type)
+          SubjectPart.from_cocina(cocina, type: type)
+        else
+          Utils.flatten_nested_values(cocina, atomic_types: SubjectPart.atomic_types).flat_map do |value|
+            SubjectPart.from_cocina(value, type: value["type"] || type)
+          end
+        end
       end
     end
   end
 end
-
-# Map Cocina subject types to specific SubjectValue classes for rendering.
-# @see SubjectValue#type
-SUBJECT_VALUE_TYPES = {
-  "person" => CocinaDisplay::Subjects::NameSubjectValue,
-  "family" => CocinaDisplay::Subjects::NameSubjectValue,
-  "organization" => CocinaDisplay::Subjects::NameSubjectValue,
-  "conference" => CocinaDisplay::Subjects::NameSubjectValue,
-  "event" => CocinaDisplay::Subjects::NameSubjectValue,
-  "name" => CocinaDisplay::Subjects::NameSubjectValue,
-  "title" => CocinaDisplay::Subjects::TitleSubjectValue,
-  "time" => CocinaDisplay::Subjects::TemporalSubjectValue,
-  "area" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "city" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "city section" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "continent" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "country" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "county" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "coverage" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "extraterrestrial area" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "island" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "place" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "region" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "state" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "territory" => CocinaDisplay::Subjects::PlaceSubjectValue,
-  "point coordinates" => CocinaDisplay::Subjects::CoordinatesSubjectValue,
-  "map coordinates" => CocinaDisplay::Subjects::CoordinatesSubjectValue,
-  "bounding box coordinates" => CocinaDisplay::Subjects::CoordinatesSubjectValue
-}.freeze

--- a/spec/concerns/subjects_spec.rb
+++ b/spec/concerns/subjects_spec.rb
@@ -107,6 +107,76 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         is_expected.to eq(["Presidents", "Election"])
       end
     end
+
+    context "with parallel value topic subjects" do
+      # from druid:vb138by0948
+      let(:subjects) do
+        [
+          {
+            "parallelValue" => [
+              {
+                "structuredValue" => [
+                  {
+                    "value" => "Types of images",
+                    "type" => "topic",
+                    "source" => {
+                      "code" => "local"
+                    }
+                  },
+                  {
+                    "value" => "Photography",
+                    "type" => "genre",
+                    "source" => {
+                      "code" => "local"
+                    }
+                  }
+                ],
+                "valueLanguage" => {
+                  "code" => "eng",
+                  "source" => {
+                    "code" => "iso639-2b"
+                  },
+                  "valueScript" => {
+                    "code" => "Latn",
+                    "source" => {
+                      "code" => "iso15924"
+                    }
+                  }
+                }
+              },
+              {
+                "structuredValue" => [
+                  {
+                    "value" => "画像の種類",
+                    "type" => "genre"
+                  },
+                  {
+                    "value" => "写真",
+                    "type" => "topic"
+                  }
+                ],
+                "valueLanguage" => {
+                  "code" => "jpn",
+                  "source" => {
+                    "code" => "iso639-2b"
+                  },
+                  "valueScript" => {
+                    "code" => "Jpan",
+                    "source" => {
+                      "code" => "iso15924"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      end
+
+      it "extracts the topic values from the parallel values" do
+        is_expected.to eq(["Types of images", "写真"])
+      end
+    end
   end
 
   describe "#subject_names" do
@@ -537,6 +607,86 @@ RSpec.describe CocinaDisplay::CocinaRecord do
           ]
         ))
       )
+    end
+
+    context "with parallelValued subjects" do
+      # from druid:vb138by0948
+      let(:subjects) do
+        [
+          {
+            "parallelValue" => [
+              {
+                "structuredValue" => [
+                  {
+                    "value" => "Types of images",
+                    "type" => "topic",
+                    "source" => {
+                      "code" => "local"
+                    }
+                  },
+                  {
+                    "value" => "Photography",
+                    "type" => "genre",
+                    "source" => {
+                      "code" => "local"
+                    }
+                  }
+                ],
+                "valueLanguage" => {
+                  "code" => "eng",
+                  "source" => {
+                    "code" => "iso639-2b"
+                  },
+                  "valueScript" => {
+                    "code" => "Latn",
+                    "source" => {
+                      "code" => "iso15924"
+                    }
+                  }
+                }
+              },
+              {
+                "structuredValue" => [
+                  {
+                    "value" => "画像の種類",
+                    "type" => "genre"
+                  },
+                  {
+                    "value" => "写真",
+                    "type" => "topic"
+                  }
+                ],
+                "valueLanguage" => {
+                  "code" => "jpn",
+                  "source" => {
+                    "code" => "iso639-2b"
+                  },
+                  "valueScript" => {
+                    "code" => "Jpan",
+                    "source" => {
+                      "code" => "iso15924"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      end
+
+      it "uses the vernacular value for display" do
+        expect(subject.first.objects.first).to have_vernacular
+        expect(CocinaDisplay::DisplayData.to_hash(subject)).to eq(
+          {
+            "Subject" => ["画像の種類 > 写真"]
+          }
+        )
+      end
+
+      it "stores the translated values for access" do
+        expect(subject.first.objects.first).to have_translation
+        expect(subject.first.objects.first.translated_value.to_s).to eq("Types of images > Photography")
+      end
     end
   end
 end


### PR DESCRIPTION
This adds handling for subjects that can have parallel values,
as on vb138by0948.

For indexing purposes, the individual parallel values are all
still indexed separately. For display, the main value is shown
and the others are accessible using helper methods, as with
other kinds of things that can be parallel.

Adds a bit of new logic to "detect" translated values when there
is a non-English value with a parallel sibling that is in English.

Closes #322
