### PR TITLE
Avoid modifying passed in parameters

### DIFF
--- a/lib/cocina_display/concerns/url_helpers.rb
+++ b/lib/cocina_display/concerns/url_helpers.rb
@@ -19,8 +19,11 @@ module CocinaDisplay
       def oembed_url(params: {})
         return if (!is_a?(CocinaDisplay::RelatedResource) && collection?) || purl_url.blank?
 
-        params[:url] ||= purl_url
-        "#{purl_base_url}/embed.json?#{params.to_query}"
+        ### Note that searchworks_traject_indexer sends in a single instance of params for all oembed_url calls.
+        ### We dup the params to avoid modifying the original hash.
+        embed_params = params.dup
+        embed_params[:url] ||= purl_url
+        "#{purl_base_url}/embed.json?#{embed_params.to_query}"
       end
 
       # The download URL to get the entire object as a .zip file.

--- a/spec/concerns/url_helpers_spec.rb
+++ b/spec/concerns/url_helpers_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 
 RSpec.describe CocinaDisplay::CocinaRecord do
-  let(:druid) { "bx658jh7339" }
   let(:cocina_json) { File.read(file_fixture("#{druid}.json")) }
-  let(:cocina_doc) { JSON.parse(cocina_json) }
 
   subject { described_class.from_json(cocina_json) }
 
@@ -35,6 +33,17 @@ RSpec.describe CocinaDisplay::CocinaRecord do
 
       it "returns the correct oEmbed URL" do
         expect(subject.oembed_url).to eq "https://sul-purl-stage.stanford.edu/embed.json?url=https%3A%2F%2Fsul-purl-stage.stanford.edu%2Fqr918wy2257"
+      end
+    end
+
+    context "with hide title" do
+      let(:shared_args) { {hide_title: true} }
+      let(:druid) { "bx658jh7339" }
+      let(:other_subject) { described_class.from_json(File.read(file_fixture("bb099mt5053.json"))) }
+
+      it "returns urls" do
+        expect(subject.oembed_url(params: shared_args)).to eq "https://purl.stanford.edu/embed.json?hide_title=true&url=https%3A%2F%2Fpurl.stanford.edu%2Fbx658jh7339"
+        expect(other_subject.oembed_url(params: shared_args)).to eq "https://purl.stanford.edu/embed.json?hide_title=true&url=https%3A%2F%2Fpurl.stanford.edu%2Fbb099mt5053"
       end
     end
   end


### PR DESCRIPTION
Otherwise the passed in hash, which may be used multiple times, could have a modified state.