### PR TITLE
Pass invalid values to Honeybadger as context

### DIFF
--- a/lib/cocina_display/contributors/role.rb
+++ b/lib/cocina_display/contributors/role.rb
@@ -53,7 +53,7 @@ module CocinaDisplay
 
         Role.marc_relators.fetch(code)
       rescue
-        CocinaDisplay.notifier&.notify("Invalid marc relator: #{code}")
+        CocinaDisplay.notifier&.notify("Invalid marc relator.", context: {code: code})
         nil
       end
 

--- a/lib/cocina_display/dates/date.rb
+++ b/lib/cocina_display/dates/date.rb
@@ -83,7 +83,7 @@ module CocinaDisplay
       # @return [String]
       def self.normalize_to_edtf(value)
         unless value
-          notifier&.notify("Invalid date value: #{value}")
+          notifier&.notify("Invalid date value.", context: {value: value})
           return
         end
 
@@ -513,7 +513,7 @@ module CocinaDisplay
         begin
           date = ISO8601::Date.new(value)
         rescue ISO8601::Errors::UnknownPattern
-          notifier&.notify("Invalid date value \"#{value}\" for iso8601 encoding")
+          notifier&.notify("Invalid date value for iso8601 encoding.", context: {value: value})
           return nil
         end
 
@@ -532,7 +532,7 @@ module CocinaDisplay
         when /^\d{4}-\d{3}$/, /^\d{7}$/
           ::Date.edtf(date.to_s)
         else
-          notifier&.notify("Unhandled date value \"#{value}\" for iso8601 encoding")
+          notifier&.notify("Unhandled date value for iso8601 encoding.", context: {value: value})
           nil
         end
       end
@@ -542,7 +542,7 @@ module CocinaDisplay
     class W3cdtfFormat < Date
       def self.normalize_to_edtf(value)
         unless value
-          notifier&.notify("Invalid date value: #{value}")
+          notifier&.notify("Invalid date value for W3CDTF encoding.", context: {value: value})
           return
         end
         super.gsub("-00", "")

--- a/spec/concerns/subjects_spec.rb
+++ b/spec/concerns/subjects_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
 
         it "returns the value as a string and notifies of a parse error" do
           is_expected.to eq(["d1843"])
-          expect(notifier).to have_received(:notify).with("Invalid date value \"d1843\" for iso8601 encoding")
+          expect(notifier).to have_received(:notify).with("Invalid date value for iso8601 encoding.", context: {value: "d1843"})
         end
       end
     end


### PR DESCRIPTION
Rather than as part of the notification.  This allows Honeybadger to group them rather than consider each an individual error