### PR TITLE
A full record can have a druid, but a RelatedResource may not

### DIFF
--- a/lib/cocina_display/cocina_record.rb
+++ b/lib/cocina_display/cocina_record.rb
@@ -6,6 +6,7 @@ module CocinaDisplay
     include CocinaDisplay::Concerns::Accesses
     include CocinaDisplay::Concerns::Events
     include CocinaDisplay::Concerns::Contributors
+    include CocinaDisplay::Concerns::Druid
     include CocinaDisplay::Concerns::Identifiers
     include CocinaDisplay::Concerns::Notes
     include CocinaDisplay::Concerns::Titles

--- a/lib/cocina_display/concerns/druid.rb
+++ b/lib/cocina_display/concerns/druid.rb
@@ -1,0 +1,24 @@
+module CocinaDisplay
+  module Concerns
+    # Methods for extracting and formatting identifiers from Cocina records.
+    module Druid
+      # The DRUID for the object, with the +druid:+ prefix.
+      # @note A {RelatedResource} may not have a DRUID, but could have a purl URL.
+      # @return [String, nil]
+      # @example
+      #   record.druid #=> "druid:bb099mt5053"
+      def druid
+        cocina_doc["externalIdentifier"]
+      end
+
+      # The DRUID for the object, without the +druid:+ prefix.
+      # @note A {RelatedResource} may not have a DRUID.
+      # @return [String, nil]
+      # @example
+      #   record.bare_druid #=> "bb099mt5053"
+      def bare_druid
+        druid.delete_prefix("druid:")
+      end
+    end
+  end
+end

--- a/lib/cocina_display/concerns/identifiers.rb
+++ b/lib/cocina_display/concerns/identifiers.rb
@@ -2,24 +2,6 @@ module CocinaDisplay
   module Concerns
     # Methods for extracting and formatting identifiers from Cocina records.
     module Identifiers
-      # The DRUID for the object, with the +druid:+ prefix.
-      # @note A {RelatedResource} may not have a DRUID.
-      # @return [String, nil]
-      # @example
-      #   record.druid #=> "druid:bb099mt5053"
-      def druid
-        cocina_doc["externalIdentifier"] || purl_url&.split("/")&.last
-      end
-
-      # The DRUID for the object, without the +druid:+ prefix.
-      # @note A {RelatedResource} may not have a DRUID.
-      # @return [String, nil]
-      # @example
-      #   record.bare_druid #=> "bb099mt5053"
-      def bare_druid
-        druid&.delete_prefix("druid:")
-      end
-
       # The DOI for the object, if there is one – just the identifier part.
       # @return [String, nil]
       # @example

--- a/lib/cocina_display/concerns/structural.rb
+++ b/lib/cocina_display/concerns/structural.rb
@@ -101,10 +101,11 @@ module CocinaDisplay
       end
 
       # DRUIDs of virtual objects this object is a part of.
+      # NOTE: not all virtual objects have this relationship in the description.related_resources.
       # @return [Array<String>]
       # @example "hj097bm8879"
       def virtual_object_parents
-        related_resources.filter { |res| res.type == "part of" }.map(&:druid).compact_blank
+        related_resources.filter_map { |res| res.purl_url&.split("/")&.last if res.type == "part of" }.compact_blank
       end
 
       # The thumbnail file for this object, if any.

--- a/lib/cocina_display/structural/file.rb
+++ b/lib/cocina_display/structural/file.rb
@@ -10,9 +10,9 @@ module CocinaDisplay
 
       # Initialize the File with Cocina file data.
       # @param cocina [Hash] Cocina structured data for a single file
-      # @param druid [String, nil] DRUID of the object this file belongs to
+      # @param druid [String] DRUID (without "druid:" prefix) of the object this file belongs to
       # @note Staging objects can't infer their DRUID and need it passed in explicitly.
-      def initialize(cocina, base_url: "https://stacks.stanford.edu", druid: nil)
+      def initialize(cocina, druid:, base_url: "https://stacks.stanford.edu")
         @cocina = cocina
         @base_url = base_url
         @druid = druid
@@ -92,42 +92,24 @@ module CocinaDisplay
       # @return [String, nil]
       # @example "ts786ny5936%2FPC0170_s1_E_0204"
       def iiif_id
-        ERB::Util.url_encode(file_id.delete_suffix(".jp2")) if file_id.present? && jp2_image?
+        ERB::Util.url_encode(file_id.delete_suffix(".jp2")) if jp2_image?
       end
 
       # Generate a download URL for this file from stacks.
-      # @return [String, nil]
+      # @return [String]
       def download_url
-        return unless filename.present?
-
         "#{base_url}/file/druid:#{druid}/#{ERB::Util.url_encode(filename)}"
       end
 
       private
 
-      # External identifier for the file, minus the URL prefix.
-      # @return [String, nil]
-      # @note Staging and production formats differ.
-      # @example production
-      #   "fn851zf9475-fn851zf9475_1/fn851zf9475_00_0001.jp2"
-      # @example staging
-      #   "ddbd323d-0dd9-4f14-ba72-336c2bccfb29"
-      def external_id
-        cocina["externalIdentifier"]&.delete_prefix("https://cocina.sul.stanford.edu/file/")
-      end
-
-      # The DRUID of the object this file belongs to.
-      # @note Staging objects can't infer this from the externalIdentifier.
-      # @return [String, nil]
-      def druid
-        @druid || external_id.split("-").first if external_id.present?
-      end
+      attr_reader :druid
 
       # Combination of the DRUID and filename to uniquely identify the file.
-      # @return [String, nil]
+      # @return [String]
       # @example "ts786ny5936/PC0170_s1_E_0204.jp2"
       def file_id
-        "#{druid}/#{filename}" if druid.present? && filename.present?
+        "#{druid}/#{filename}"
       end
     end
   end

--- a/lib/cocina_display/structural/file_set.rb
+++ b/lib/cocina_display/structural/file_set.rb
@@ -10,9 +10,9 @@ module CocinaDisplay
 
       # Initialize the FileSet with Cocina structural data.
       # @param cocina [Hash] Cocina structured data for a single FileSet
+      # @param druid [String] DRUID (without "druid:" prefix) of the object this fileset belongs to
       # @param base_url [String] URL to Stacks environment that will serve this fileset
-      # @param druid [String, nil] DRUID of the object this fileset belongs to
-      def initialize(cocina, base_url: "https://stacks.stanford.edu", druid: nil)
+      def initialize(cocina, druid:, base_url: "https://stacks.stanford.edu")
         @cocina = cocina
         @base_url = base_url
         @druid = druid

--- a/spec/concerns/structural_spec.rb
+++ b/spec/concerns/structural_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     context "when there is an image but it has zero dimensions" do
       let(:cocina_doc) do
         {
+          "externalIdentifier" => "druid:bk264hq9320",
           "structural" => {
             "contains" => [
               {

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
 
 RSpec.describe CocinaDisplay::Structural::File do
-  subject { described_class.new(cocina) }
+  subject { described_class.new(cocina, druid:) }
+  let(:druid) { "bc798xr9549" }
 
   describe "#download_url" do
     context "when file has a space" do


### PR DESCRIPTION
This refactoring reflects that and makes clear where the data for virtual_object_parents is coming from