### PR TITLE
Handle nil druids when requesting the bare DRUID

### DIFF
--- a/lib/cocina_display/concerns/druid.rb
+++ b/lib/cocina_display/concerns/druid.rb
@@ -17,7 +17,7 @@ module CocinaDisplay
       # @example
       #   record.bare_druid #=> "bb099mt5053"
       def bare_druid
-        druid.delete_prefix("druid:")
+        druid&.delete_prefix("druid:")
       end
     end
   end


### PR DESCRIPTION
This happens with objects we create in tests that may represent
an incomplete Cocina document. We want to support it because you
shouldn't need to specify a fake DRUID to test behavior.

Fixes the CI failure in
https://github.com/sul-dlss/searchworks_traject_indexer/pull/1791.
