### PR TITLE
Delegate some properties to the main Subject value

### DIFF
--- a/lib/cocina_display/subjects/subject.rb
+++ b/lib/cocina_display/subjects/subject.rb
@@ -2,8 +2,8 @@ module CocinaDisplay
   module Subjects
     # A Subject in Cocina structured data, possibly in multiple languages.
     class Subject < Parallel::Parallel
-      # String representation uses the main parallel value.
-      delegate :to_s, to: :main_value
+      # String representation and parts reference the main parallel value.
+      delegate :to_s, :delimiter, :subject_parts, :values, to: :main_value
 
       # Label used when displaying the Subject.
       # @return [String]

--- a/spec/concerns/subjects_spec.rb
+++ b/spec/concerns/subjects_spec.rb
@@ -687,6 +687,14 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         expect(subject.first.objects.first).to have_translation
         expect(subject.first.objects.first.translated_value.to_s).to eq("Types of images > Photography")
       end
+
+      it "uses the main value for individual subject parts" do
+        expect(subject.first.objects.first.values).to eq(["画像の種類", "写真"])
+      end
+
+      it "uses the main value for the delimiter" do
+        expect(subject.first.objects.first.delimiter).to eq(" > ")
+      end
     end
   end
 end


### PR DESCRIPTION
Searchworks uses these when rendering structured subjects.
