### PR TITLE
Add a helper method for getting bounding box coordinates

### DIFF
--- a/lib/cocina_display/concerns/geospatial.rb
+++ b/lib/cocina_display/concerns/geospatial.rb
@@ -39,6 +39,14 @@ module CocinaDisplay
         coordinate_objects.map(&:as_point).uniq
       end
 
+      # All valid coordinate data formatted as bounding boxes.
+      # Format is [[min_lat, min_long], [max_lat, max_long]].
+      # @note Points are not included since they can't be represented as a box.
+      # @return [Array<Array<Array<Float>>>]
+      def coordinates_as_bbox
+        coordinate_objects.map(&:as_bbox).compact.uniq
+      end
+
       # Identifiers assigned by geonames.org for places related to the object.
       # @return [Array<String>]
       # @example ["6252001", "5368361"]

--- a/lib/cocina_display/geospatial.rb
+++ b/lib/cocina_display/geospatial.rb
@@ -130,6 +130,13 @@ module CocinaDisplay
         nil
       end
 
+      # Format as a bounding box.
+      # @note This is impossible for a single point; we always return nil.
+      # @return [nil]
+      def as_bbox
+        nil
+      end
+
       # Format as a space-separated x y (longitude latitude) pair.
       # @note Limits decimals to 6 places.
       # @example "-118.2437 34.0522"
@@ -197,7 +204,7 @@ module CocinaDisplay
 
       # Format using the CQL ENVELOPE representation.
       # @note Limits decimals to 6 places.
-      # @example "ENVELOPE(-118.243700, -117.952200, 34.199600, 34.052200)"
+      # @example "ENVELOPE(-118.2437, -117.9522, 34.1996, 34.0522)"
       # @return [String]
       def as_envelope
         "ENVELOPE(%.6f, %.6f, %.6f, %.6f)" % [
@@ -214,6 +221,14 @@ module CocinaDisplay
         distance = min_point.distance(max_point)
         center = min_point.endpoint(distance / 2, azimuth)
         "%.6f %.6f" % [center.lng, center.lat]
+      end
+
+      # Format the bounding box as an array of two coordinate pairs [[S, W], [N, E]].
+      # @note Limits decimals to 6 places.
+      # @return [Array<Array<Float>>]
+      # @example [[-118.2437, 34.0522], [-117.9522, 34.1996]]
+      def as_bbox
+        [[min_point.lat, min_point.lng], [max_point.lat, max_point.lng]]
       end
     end
 

--- a/spec/concerns/geospatial_spec.rb
+++ b/spec/concerns/geospatial_spec.rb
@@ -477,6 +477,37 @@ RSpec.describe CocinaDisplay::CocinaRecord do
     end
   end
 
+  describe "#coordinates_as_bbox" do
+    context "with a point and a bounding box" do
+      let(:subjects) do
+        [
+          {
+            "type" => "point coordinates",
+            "structuredValue" => [
+              {"value" => "36.740468", "type" => "latitude"},
+              {"value" => "-121.24658", "type" => "longitude"}
+            ]
+          },
+          {
+            "type" => "bounding box coordinates",
+            "structuredValue" => [
+              {"value" => "-121.24658", "type" => "west"},
+              {"value" => "36.740468", "type" => "south"},
+              {"value" => "-120.051476", "type" => "east"},
+              {"value" => "37.633575", "type" => "north"}
+            ]
+          }
+        ]
+      end
+
+      subject { cocina_record.coordinates_as_bbox.first }
+
+      it "returns only the box in bounding box format (not the point)" do
+        is_expected.to eq([[36.740468, -121.24658], [37.633575, -120.051476]])
+      end
+    end
+  end
+
   describe "#coordinates_as_point" do
     context "with a point and a bounding box" do
       let(:subjects) do


### PR DESCRIPTION
This format of coordinates is used for sul-embed to know how
to render the map preview.
