### PR TITLE
Disable external HTTP requests using WebMock

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@ if RSpec.configuration.files_to_run.count > 1
   SimpleCov::RSpec.start(list_uncovered_lines: true)
 end
 
+# Disable external HTTP requests; tests should stub them out
+WebMock.disable_net_connect!(allow_localhost: true)
+
 require "cocina_display"
 
 RSpec.configure do |config|


### PR DESCRIPTION
We installed it but weren't using it to block requests.
