### PR TITLE
Add the ability to filter files by filename, MIME type, and role

### DIFF
--- a/lib/cocina_display/concerns/structural.rb
+++ b/lib/cocina_display/concerns/structural.rb
@@ -20,14 +20,25 @@ module CocinaDisplay
 
       # Structured data for all individual files in the object.
       # Traverses nested FileSet structure to return a flattened array.
+      # Optionally filter by filename or MIME type regex, or by role.
+      # Filters are combined with AND logic (all must match).
+      # @param filename [String, nil] Regular expression to match against filenames.
+      # @param mime_type [String, nil] Regular expression to match against MIME types.
+      # @param use [String, nil] Usage type to match against (e.g., "thumbnail").
       # @return [Array<CocinaDisplay::Structural::File>]
       # @example
       #  record.files.each do |file|
       #   puts file.filename #=> "image1.jpg"
       #   puts file.size #=> 123456
       #  end
-      def files
-        filesets.flat_map(&:files)
+      # @example Filter to only thumbnail JP2 files
+      #  record.files(filename: /\.jp2$/, use: "thumbnail")
+      def files(filename: nil, mime_type: nil, use: nil)
+        results = filesets.flat_map(&:files)
+        results.filter! { |file| file.filename =~ filename } if filename
+        results.filter! { |file| file.mime_type =~ mime_type } if mime_type
+        results.filter! { |file| file.use == use } if use
+        results
       end
 
       # All unique MIME types of files in this object.

--- a/spec/concerns/structural_spec.rb
+++ b/spec/concerns/structural_spec.rb
@@ -14,6 +14,24 @@ RSpec.describe CocinaDisplay::CocinaRecord do
       expect(subject.files.first.filename).to eq("bb099mt5053_sl.m4a")
       expect(subject.files.first.size).to eq(13832365)
     end
+
+    context "with filename filter" do
+      it "returns only files matching the filename regex" do
+        expect(subject.files(filename: /\.jp2$/).first.filename).to eq("bb099mt5053_img_1.jp2")
+      end
+    end
+
+    context "with MIME type filter" do
+      it "returns only files matching the MIME type regex" do
+        expect(subject.files(mime_type: /^audio\//).first.filename).to eq("bb099mt5053_sl.m4a")
+      end
+    end
+
+    context "with use filter" do
+      it "returns only files matching the usage" do
+        expect(subject.files(use: "annotation")).to be_empty
+      end
+    end
   end
 
   describe "#file_mime_types" do


### PR DESCRIPTION
This ports functionality originally written as a traject macro,
so that it can be used in a non-traject context and made more
generally available.

See
https://github.com/sul-dlss/searchworks_traject_indexer/blob/b6c5cbd30306906e94c7a4957742e2c273d4fddd/lib/traject/macros/cocina.rb#L164-L173.
