### PR TITLE
Fix searchworks_resource_types when no resource types are present.

### DIFF
--- a/lib/cocina_display/concerns/forms.rb
+++ b/lib/cocina_display/concerns/forms.rb
@@ -191,7 +191,7 @@ module CocinaDisplay
       # Is the object a digital resource without a more specific resource type?
       # @return [Boolean]
       def digital_only?
-        resource_type_values.all?("digital")
+        resource_type_values.present? && resource_type_values.all?("digital")
       end
 
       # Map a MODS or LC resource type to SearchWorks format value(s).

--- a/spec/concerns/forms_spec.rb
+++ b/spec/concerns/forms_spec.rb
@@ -112,6 +112,12 @@ RSpec.describe CocinaDisplay::CocinaRecord do
         is_expected.to eq(["Website", "Website|Archived website"])
       end
     end
+
+    context "with a resource that has no resource types" do
+      it "does not map" do
+        is_expected.to eq([])
+      end
+    end
   end
 
   describe "#mods_resource_types" do


### PR DESCRIPTION
This was noticed by @andrewjbtw -- when there are no resource types, "Software/Multimedia" is mistakingly added.