### PR TITLE
Remove references to public Cocina label field

### DIFF
--- a/lib/cocina_display/cocina_record.rb
+++ b/lib/cocina_display/cocina_record.rb
@@ -60,14 +60,6 @@ module CocinaDisplay
       cocina_doc["type"]&.delete_prefix("https://cocina.sul.stanford.edu/models/")
     end
 
-    # Primary processing label for the object.
-    # @note For public Cocina fetched via PURL, this is generated at publish time from the title. It will have the same value as #display_title.
-    # @see https://github.com/sul-dlss/cocina_display/issues/205#issuecomment-3781393715
-    # @return [String, nil]
-    def label
-      cocina_doc["label"]
-    end
-
     # True if the object is a collection.
     # @return [Boolean]
     def collection?

--- a/lib/cocina_display/concerns/titles.rb
+++ b/lib/cocina_display/concerns/titles.rb
@@ -26,6 +26,10 @@ module CocinaDisplay
         primary_title&.display_title
       end
 
+      # SDR no longer populates a label field with pregenerated titles; this
+      # alias is provided for backwards compatibility.
+      alias_method :label, :display_title
+
       # A string value for sorting by title that sorts missing values last.
       # If there are multiple primary titles, uses the first.
       # @see CocinaDisplay::Title#sort_title


### PR DESCRIPTION
SDR's PublicCocinaService no longer populates this field with
a generated title, so we need to generate it ourselves.

This provides an alias so that downstream code looking for a label
will get the same value.
