### PR TITLE
Adds ability to preserve keys to deep_compact_blank

### DIFF
--- a/lib/cocina_display/utils.rb
+++ b/lib/cocina_display/utils.rb
@@ -52,26 +52,31 @@ module CocinaDisplay
 
     # Recursively remove empty values from a hash, including nested hashes and arrays.
     # @param [Hash, String, NilClass] node The object to process
+    # @param [Array<String>] preserve_keys Keys that should be kept even if their value is blank
     # @return [Hash, String] The hash with empty values removed, string if the node you pass in is a string
     # @example
     #  hash = { "name" => "", "age" => nil, "address => { "city" => "Anytown", "state" => [] } }
     #  #  Utils.remove_empty_values(hash)
     #  #=> { "address" => { "city" => "Anytown" } }
-    def self.deep_compact_blank(node)
+    def self.deep_compact_blank(node, preserve_keys: [])
       return node unless node.is_a?(Hash)
 
+      preserve_keys = preserve_keys.map(&:to_s)
+
       node.each_with_object({}) do |(key, value), output|
+        preserve_key = preserve_keys.include?(key.to_s)
+
         case value
         when Hash
-          nested = deep_compact_blank(value)
-          output[key] = nested unless nested.empty?
+          nested = deep_compact_blank(value, preserve_keys: preserve_keys)
+          output[key] = nested if !nested.empty? || preserve_key
         when Array
-          compacted_array = value.map { |v| deep_compact_blank(v) }.compact_blank
-          output[key] = compacted_array unless compacted_array.empty?
+          compacted_array = value.map { |v| deep_compact_blank(v, preserve_keys: preserve_keys) }.compact_blank
+          output[key] = compacted_array if !compacted_array.empty? || preserve_key
         when TrueClass, FalseClass
           output[key] = value
         else
-          output[key] = value if value.present?
+          output[key] = value if value.present? || preserve_key
         end
       end
     end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -160,6 +160,51 @@ RSpec.describe CocinaDisplay::Utils do
         is_expected.to eq(hash)
       end
     end
+
+    context "with preserve_keys" do
+      subject { described_class.deep_compact_blank(hash, preserve_keys: ["label"]) }
+
+      let(:hash) do
+        {
+          "name" => "John Doe",
+          "label" => "",
+          "address" => {
+            "street" => "123 Main St",
+            "label" => nil,
+            "city" => ""
+          }
+        }
+      end
+
+      it "keeps blank values for the given keys" do
+        is_expected.to eq({
+          "name" => "John Doe",
+          "label" => "",
+          "address" => {
+            "street" => "123 Main St",
+            "label" => nil
+          }
+        })
+      end
+    end
+
+    context "with preserve_keys as symbols and hash keys as strings" do
+      subject { described_class.deep_compact_blank(hash, preserve_keys: [:label]) }
+
+      let(:hash) do
+        {
+          "name" => "John Doe",
+          "label" => ""
+        }
+      end
+
+      it "keeps blank values regardless of string/symbol mismatch" do
+        is_expected.to eq({
+          "name" => "John Doe",
+          "label" => ""
+        })
+      end
+    end
   end
 
   describe "#compact_and_join" do


### PR DESCRIPTION
When compacting cocina, this will remove a blank "label" which renders the cocina invalid.